### PR TITLE
Workaround over-sensitive ambiguity detection from JuliaLang/julia#36962

### DIFF
--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -22,6 +22,10 @@ include("stale_deps.jl")
 Run following tests in isolated testset:
 
 * [`test_ambiguities([testtarget, Base])`](@ref test_ambiguities)
+  (Note: To ignore ambiguities from `Base` due to
+  [JuliaLang/julia#36962](https://github.com/JuliaLang/julia/pull/36962),
+  `test_ambiguities(testtarget)` is called instead for Julia nightly
+  later than 1.6.0-DEV.816.)
 * [`test_unbound_args(testtarget)`](@ref test_unbound_args)
 * [`test_undefined_exports(testtarget)`](@ref test_undefined_exports)
 
@@ -35,7 +39,12 @@ function test_all(
     # undefined_exports = (),
 )
     @testset "Method ambiguity" begin
-        test_ambiguities([testtarget, Base]; ambiguities...)
+        if VERSION >= v"1.6.0-DEV.816"
+            @warn "Ignoring ambiguities from `Base` introduced by JuliaLang/julia#36962"
+            test_ambiguities([testtarget]; ambiguities...)
+        else
+            test_ambiguities([testtarget, Base]; ambiguities...)
+        end
     end
     @testset "Unbound type parameters" begin
         test_unbound_args(testtarget)

--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -40,7 +40,7 @@ function test_all(
 )
     @testset "Method ambiguity" begin
         if VERSION >= v"1.6.0-DEV.816"
-            @warn "Ignoring ambiguities from `Base` introduced by JuliaLang/julia#36962"
+            @warn "Ignoring ambiguities from `Base` to workaround JuliaLang/julia#36962"
             test_ambiguities([testtarget]; ambiguities...)
         else
             test_ambiguities([testtarget, Base]; ambiguities...)

--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -25,7 +25,9 @@ Run following tests in isolated testset:
   (Note: To ignore ambiguities from `Base` due to
   [JuliaLang/julia#36962](https://github.com/JuliaLang/julia/pull/36962),
   `test_ambiguities(testtarget)` is called instead for Julia nightly
-  later than 1.6.0-DEV.816.)
+  later than 1.6.0-DEV.816 for now. Depending on how
+  JuliaLang/julia#36962 is resolved, this special-casing may be
+  removed in later versions of Aqua.jl.)
 * [`test_unbound_args(testtarget)`](@ref test_unbound_args)
 * [`test_undefined_exports(testtarget)`](@ref test_undefined_exports)
 

--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -21,8 +21,8 @@ false-positive.
   Note that the default here (`true`) is different from
   `detect_ambiguities`.  This is for testing ambiguities in methods
   defined in all sub-modules.
-- `imported::Bool = false`: Passed to `Test.detect_ambiguities`.
-- `ambiguous_bottom::Bool = false`: Passed to `Test.detect_ambiguities`.
+- Other keyword arguments such as `imported` and `ambiguous_bottom`
+  are passed to `Test.detect_ambiguities` as-is.
 """
 test_ambiguities(packages; kwargs...) =
     _test_ambiguities(aspkgids(packages); kwargs...)
@@ -92,16 +92,10 @@ function _test_ambiguities(
     color::Union{Bool, Nothing} = nothing,
     exclude::AbstractArray = [],
     # Options to be passed to `Test.detect_ambiguities`:
-    recursive::Bool = true,
-    imported::Bool = false,
-    ambiguous_bottom::Bool = false,
+    detect_ambiguities_options...,
 )
     packages_repr = reprpkgids(collect(packages))
-    options_repr = repr((
-        recursive = recursive,
-        imported = imported,
-        ambiguous_bottom = ambiguous_bottom,
-    ))
+    options_repr = checked_repr((; recursive = true, detect_ambiguities_options...))
     exclude_repr = reprexclude(normalize_and_check_exclude(exclude))
 
     # Ambiguity test is run inside a clean process.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -56,3 +56,17 @@ function root_project_or_failed_lazytest(pkg::PkgId)
     end
     return root_project_path
 end
+
+
+module _TempModule
+end
+
+eval_string(code::AbstractString) = include_string(_TempModule, code)
+
+function checked_repr(obj)
+    code = repr(obj)
+    if !isequal(eval_string(code), obj)
+        error("`$repr` is not `repr`-safe")
+    end
+    return code
+end


### PR DESCRIPTION
This is for avoiding errors like

> ```
> ERROR: MethodError: no method matching detect_ambiguities(::Module, ::Module; recursive=true, imported=false, ambiguous_bottom=false)
> Closest candidates are:
>   detect_ambiguities(::Any...; recursive, ambiguous_bottom) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1423 got unsupported keyword argument "imported"
> ```
>
> --- https://travis-ci.com/github/JuliaFolds/BangBang.jl/jobs/381666899#L338

Also:
https://github.com/JuliaFolds/Transducers.jl/runs/1077261987#step:6:37


## Commit Message
Workaround over-sensitive ambiguity detection from JuliaLang/julia#36962 (#32)

* Do not hard-code default options for `Test.detect_ambiguities`
* Ignore ambiguities from Base for now