### PR TITLE
Add test_deps_compat to check missing compat in root Project.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Aqua.jl provides functions to run a few automatable checks for Julia packages:
 * There are no stale dependencies listed in `Project.toml` (optional).
 * Check that test target of the root project `Project.toml` and test project
   (`test/Project.toml`) are consistent (optional).
+* Check that all external packages listed in `deps` have corresponding
+  `compat` entry (optional).
 
 ## Quick usage
 

--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -6,7 +6,7 @@ module Aqua
 end Aqua
 
 using Base: PkgId, UUID
-using Pkg: TOML
+using Pkg: Pkg, TOML
 using Test
 
 include("utils.jl")
@@ -15,6 +15,7 @@ include("unbound_args.jl")
 include("exports.jl")
 include("project_extras.jl")
 include("stale_deps.jl")
+include("deps_compat.jl")
 
 """
     test_all(testtarget::Module)

--- a/src/deps_compat.jl
+++ b/src/deps_compat.jl
@@ -1,0 +1,62 @@
+"""
+    Aqua.test_deps_compat(package)
+
+Test that `Project.toml` of `package` list all `compat` for `deps`.
+
+# Arguments
+- `packages`: a top-level `Module`, a `Base.PkgId`, or a collection of
+  them.
+"""
+test_deps_compat
+function test_deps_compat(packages)
+    @testset "$(result.label)" for result in analyze_deps_compat(packages)
+        @debug result.label result
+        @test result ⊜ true
+    end
+end
+
+analyze_deps_compat(packages) = [_analyze_deps_compat_1(pkg) for pkg in aspkgids(packages)]
+
+function _analyze_deps_compat_1(pkg::PkgId)
+    result = root_project_or_failed_lazytest(pkg)
+    result isa LazyTestResult && return result
+    root_project_path = result
+    return _analyze_deps_compat_2(pkg, root_project_path, TOML.parsefile(root_project_path))
+end
+
+function _analyze_deps_compat_2(pkg::PkgId, root_project_path, prj)
+    label = "$pkg"
+
+    deps = get(prj, "deps", nothing)
+    if deps === nothing
+        # Should it pass?
+        return LazyTestResult(label, "`$root_project_path` does not have `deps`", false)
+    end
+    compat = get(prj, "compat", nothing)
+    if compat === nothing
+        return LazyTestResult(label, "`$root_project_path` does not have `compat`", false)
+    end
+
+    stdlib_name_from_uuid = stdlibs()
+    stdlib_deps = filter!(
+        !isnothing,
+        [get(stdlib_name_from_uuid, UUID(uuid), nothing) for (_, uuid) in deps],
+    )
+    missing_compat = setdiff(setdiff(keys(deps), keys(compat)), stdlib_deps)
+    if !isempty(missing_compat)
+        msg = join(
+            [
+                "`$root_project_path` does not specify `compat` for:"
+                sort!(collect(missing_compat))
+            ],
+            "\n",
+        )
+        return LazyTestResult(label, msg, false)
+    end
+
+    return LazyTestResult(
+        label,
+        "`$root_project_path` specifies `compat` for all `deps`",
+        true,
+    )
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -70,3 +70,10 @@ function checked_repr(obj)
     end
     return code
 end
+
+if VERSION < v"1.4"
+    const stdlibs = Pkg.Types.stdlib
+else
+    # https://github.com/JuliaLang/Pkg.jl/pull/1559
+    const stdlibs = Pkg.Types.stdlibs
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,7 @@
+if !@isdefined(isnothing)
+    isnothing(x) = x === nothing
+end
+
 struct LazyTestResult
     label::String
     message::String

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -71,9 +71,14 @@ function checked_repr(obj)
     return code
 end
 
-if VERSION < v"1.4"
-    const stdlibs = Pkg.Types.stdlib
-else
-    # https://github.com/JuliaLang/Pkg.jl/pull/1559
-    const stdlibs = Pkg.Types.stdlibs
+const stdlibs = try
+    Pkg.Types.stdlibs
+catch
+    try
+        # https://github.com/JuliaLang/Pkg.jl/pull/1559
+        Pkg.Types.stdlib  # julia < 1.4
+    catch
+        # https://github.com/JuliaLang/Pkg.jl/pull/696
+        Pkg.Types.gather_stdlib_uuids  # julia < 1.1
+    end
 end

--- a/test/test_deps_compat.jl
+++ b/test/test_deps_compat.jl
@@ -1,0 +1,85 @@
+module TestDepsCompat
+
+include("preamble.jl")
+using Aqua: PkgId, UUID, _analyze_deps_compat_2, ⊜
+
+const DictSA = Dict{String,Any}
+
+@testset "_analyze_deps_compat_2" begin
+    pkg = PkgId(UUID(42), "TargetPkg")
+    root_project_path = "DUMMY_PATH"
+    @testset "pass" begin
+        @test _analyze_deps_compat_2(
+            pkg,
+            root_project_path,
+            DictSA("deps" => DictSA(), "compat" => DictSA("julia" => "1")),
+        ) ⊜ true
+        @test _analyze_deps_compat_2(
+            pkg,
+            root_project_path,
+            DictSA(
+                "deps" => DictSA("SHA" => "ea8e919c-243c-51af-8825-aaa63cd721ce"),
+                "compat" => DictSA("julia" => "1"),
+            ),
+        ) ⊜ true
+        @test _analyze_deps_compat_2(
+            pkg,
+            root_project_path,
+            DictSA(
+                "deps" => DictSA("PkgA" => "229717a1-0d13-4dfb-ba8f-049672e31205"),
+                "compat" => DictSA("julia" => "1", "PkgA" => "1.0"),
+            ),
+        ) ⊜ true
+    end
+    @testset "failure" begin
+        @testset "does not have `deps`" begin
+            # Not sure if it should fail or passs:
+            t = _analyze_deps_compat_2(pkg, root_project_path, DictSA())
+            @test t ⊜ false
+            @test occursin("does not have `deps`", string(t))
+        end
+
+        @testset "does not have `compat`" begin
+            t = _analyze_deps_compat_2(
+                pkg,
+                root_project_path,
+                DictSA("deps" => DictSA("PkgA" => "229717a1-0d13-4dfb-ba8f-049672e31205")),
+            )
+            @test t ⊜ false
+            @test occursin("does not have `compat`", string(t))
+        end
+
+        @testset "does not specify `compat` for PkgA" begin
+            t = _analyze_deps_compat_2(
+                pkg,
+                root_project_path,
+                DictSA(
+                    "deps" => DictSA("PkgA" => "229717a1-0d13-4dfb-ba8f-049672e31205"),
+                    "compat" => DictSA("julia" => "1"),
+                ),
+            )
+            @test t ⊜ false
+            @test occursin("does not specify `compat` for", string(t))
+            @test occursin("PkgA", string(t))
+        end
+
+        @testset "does not specify `compat` for PkgB" begin
+            t = _analyze_deps_compat_2(
+                pkg,
+                root_project_path,
+                DictSA(
+                    "deps" => DictSA(
+                        "PkgA" => "229717a1-0d13-4dfb-ba8f-049672e31205",
+                        "PkgB" => "3d97d89c-7c41-49ae-981c-14fe13cc7943",
+                    ),
+                    "compat" => DictSA("julia" => "1", "PkgA" => "1.0"),
+                ),
+            )
+            @test t ⊜ false
+            @test occursin("does not specify `compat` for", string(t))
+            @test occursin("PkgB", string(t))
+        end
+    end
+end
+
+end  # module

--- a/test/test_smoke.jl
+++ b/test/test_smoke.jl
@@ -8,4 +8,8 @@ using Test
     Aqua.test_stale_deps(Aqua)
 end
 
+@testset "test_deps_compat" begin
+    Aqua.test_deps_compat(Aqua)
+end
+
 end  # module


### PR DESCRIPTION
close #31

## Commit Message
Add test_deps_compat to check missing compat in root Project.toml (#33)

A new function `test_deps_compat` runs a test to check if
`Project.toml` has enough `compat` entries.