### PR TITLE
Make test_all configurable with flags

### DIFF
--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -31,29 +31,66 @@ Run following tests in isolated testset:
   removed in later versions of Aqua.jl.)
 * [`test_unbound_args(testtarget)`](@ref test_unbound_args)
 * [`test_undefined_exports(testtarget)`](@ref test_undefined_exports)
+* [`test_project_extras(testtarget)`](@ref test_project_extras) (optional)
+* [`test_stale_deps(testtarget)`](@ref test_stale_deps) (optional)
+* [`test_deps_compat(testtarget)`](@ref test_deps_compat) (optional)
+
+The keyword argument `\$x` (e.g., `ambiguities`) can be used to
+control whether or not to run `test_\$x` (e.g., `test_ambiguities`).
+If `test_\$x` supports keyword arguments, a `NamedTuple` can also be
+passed to `\$x` to specify the keyword arguments for `test_\$x`.
 
 # Keyword Arguments
-- `ambiguities`: Keyword arguments passed to [`test_ambiguities`](@ref).
+- `ambiguities = true`
+- `unbound_args = true`
+- `undefined_exports = true`
+- `project_extras = false`
+- `stale_deps = false`
+- `deps_compat = false`
 """
 function test_all(
     testtarget::Module;
-    ambiguities = (),
-    # unbound_args = (),
-    # undefined_exports = (),
+    ambiguities = true,
+    unbound_args = true,
+    undefined_exports = true,
+    project_extras = false,
+    stale_deps = false,
+    deps_compat = false,
 )
     @testset "Method ambiguity" begin
-        if VERSION >= v"1.6.0-DEV.816"
-            @warn "Ignoring ambiguities from `Base` to workaround JuliaLang/julia#36962"
-            test_ambiguities([testtarget]; ambiguities...)
-        else
-            test_ambiguities([testtarget, Base]; ambiguities...)
+        if ambiguities !== false
+            if VERSION >= v"1.6.0-DEV.816"
+                @warn "Ignoring ambiguities from `Base` to workaround JuliaLang/julia#36962"
+                test_ambiguities([testtarget]; askwargs(ambiguities)...)
+            else
+                test_ambiguities([testtarget, Base]; askwargs(ambiguities)...)
+            end
         end
     end
     @testset "Unbound type parameters" begin
-        test_unbound_args(testtarget)
+        if unbound_args !== false
+            test_unbound_args(testtarget; askwargs(unbound_args)...)
+        end
     end
     @testset "Undefined exports" begin
-        test_undefined_exports(testtarget)
+        if undefined_exports !== false
+            test_undefined_exports(testtarget; askwargs(undefined_exports)...)
+        end
+    end
+    @testset "Compare Project.toml and test/Project.toml" begin
+        if project_extras !== false
+            test_project_extras(testtarget; askwargs(project_extras)...)
+        end
+    end
+    @testset "Stale dependencies" begin
+        if stale_deps !== false
+            test_stale_deps(testtarget; askwargs(stale_deps)...)
+        end
+    end
+    @testset "Compat bounds" begin
+        if deps_compat !== false
+            test_deps_compat(testtarget; askwargs(deps_compat)...)
+        end
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,6 +2,14 @@ if !@isdefined(isnothing)
     isnothing(x) = x === nothing
 end
 
+askwargs(kwargs) = (; kwargs...)
+function askwargs(flag::Bool)
+    if !flag
+        throw(ArgumentError("expect `true`"))
+    end
+    return NamedTuple()
+end
+
 struct LazyTestResult
     label::String
     message::String

--- a/test/test_smoke.jl
+++ b/test/test_smoke.jl
@@ -2,14 +2,13 @@ module TestSmoke
 
 using Aqua
 Aqua.test_all(Aqua)
-
-using Test
-@testset "test_stale_deps" begin
-    Aqua.test_stale_deps(Aqua)
-end
-
-@testset "test_deps_compat" begin
-    Aqua.test_deps_compat(Aqua)
-end
+Aqua.test_all(
+    Aqua;
+    ambiguities = false,
+    unbound_args = false,
+    undefined_exports = false,
+    stale_deps = true,
+    deps_compat = true,
+)
 
 end  # module

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,13 @@
+module TestUtils
+
+using Aqua: askwargs
+using Test
+
+@testset "askwargs" begin
+    @test_throws ArgumentError("expect `true`") askwargs(false)
+    @test askwargs(true) === NamedTuple()
+    @test askwargs(()) === NamedTuple()
+    @test askwargs((a = 1,)) === (a = 1,)
+end
+
+end  # module


### PR DESCRIPTION
## Commit Message
Make test_all configurable with flags (#35)

There are a lot of repetition across packages for running optional
tests.  Let's avoid this by including all tests in `test_all` and
turning on/off by flags.