### PR TITLE
Fix test_deps_compat for Project.toml without deps table

### DIFF
--- a/src/deps_compat.jl
+++ b/src/deps_compat.jl
@@ -29,8 +29,7 @@ function _analyze_deps_compat_2(pkg::PkgId, root_project_path, prj)
 
     deps = get(prj, "deps", nothing)
     if deps === nothing
-        # Should it pass?
-        return LazyTestResult(label, "`$root_project_path` does not have `deps`", false)
+        return LazyTestResult(label, "`$root_project_path` does not have `deps`", true)
     end
     compat = get(prj, "compat", nothing)
     if compat === nothing

--- a/test/test_deps_compat.jl
+++ b/test/test_deps_compat.jl
@@ -33,7 +33,7 @@ const DictSA = Dict{String,Any}
         @testset "does not have `deps`" begin
             # Not sure if it should fail or passs:
             t = _analyze_deps_compat_2(pkg, root_project_path, DictSA())
-            @test t ⊜ false
+            @test t ⊜ true
             @test occursin("does not have `deps`", string(t))
         end
     end

--- a/test/test_deps_compat.jl
+++ b/test/test_deps_compat.jl
@@ -30,15 +30,14 @@ const DictSA = Dict{String,Any}
                 "compat" => DictSA("julia" => "1", "PkgA" => "1.0"),
             ),
         ) ⊜ true
-    end
-    @testset "failure" begin
         @testset "does not have `deps`" begin
             # Not sure if it should fail or passs:
             t = _analyze_deps_compat_2(pkg, root_project_path, DictSA())
             @test t ⊜ false
             @test occursin("does not have `deps`", string(t))
         end
-
+    end
+    @testset "failure" begin
         @testset "does not have `compat`" begin
             t = _analyze_deps_compat_2(
                 pkg,


### PR DESCRIPTION
https://travis-ci.com/github/JuliaFolds/InitialValues.jl/jobs/382136912#L291-L295

## Commit Message
Fix test_deps_compat for Project.toml without deps table (#38)

To run `test_deps_compat` by default in Aqua 0.5 (#36), it should work
Project.toml file without `deps`.