### PR TITLE
Extract stdlib names from tuple on Julia master

### DIFF
--- a/src/deps_compat.jl
+++ b/src/deps_compat.jl
@@ -24,6 +24,7 @@ function _analyze_deps_compat_1(pkg::PkgId)
     return _analyze_deps_compat_2(pkg, root_project_path, TOML.parsefile(root_project_path))
 end
 
+# For supporting Julia 1.8-DEV and above which give us a tuple instead of a string
 _unwrap_name(x::Tuple) = first(x)
 _unwrap_name(x::String) = x
 _unwrap_name(x::Nothing) = x


### PR DESCRIPTION
On Julia master:
```julia
julia> Aqua.stdlibs()
Dict{Base.UUID, Tuple{String, Union{Nothing, VersionNumber}}} with 58 entries:
  UUID("efcefdf7-47ab-520b-bdef-62a2eaa19f15") => ("PCRE2_jll", v"10.36.0+2")
  UUID("745a5e78-f969-53e9-954f-d19f2f74f4e3") => ("LibUnwind_jll", v"1.3.2+0")
  UUID("a63ad114-7e13-5084-954f-fe012c677804") => ("Mmap", nothing)
  UUID("76f85450-5226-5b5a-8eaa-529ad045b433") => ("LibGit2", nothing)
  UUID("2a0f44e3-6c83-55bd-87e4-b1978d98bd5f") => ("Base64", nothing)
  UUID("05823500-19ac-5b8b-9628-191a04bc5112") => ("OpenLibm_jll", v"0.7.5+0")
  UUID("56f22d72-fd6d-98f1-02f0-08ddc0907c33") => ("Artifacts", nothing)
  UUID("b77e0a4c-d291-57a0-90e8-8db25a27a240") => ("InteractiveUtils", nothing)
  UUID("8bf52ea8-c179-5cab-976a-9e18b702a9bc") => ("CRC32c", nothing)
  UUID("05ff407c-b0c1-5878-9df8-858cc2e60c36") => ("dSFMT_jll", v"2.2.4+1")
  UUID("7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee") => ("FileWatching", nothing)
  UUID("e37daf67-58a4-590a-8e99-b0245dd2ffc5") => ("LibGit2_jll", v"1.2.3+0")
  UUID("bea87d4a-7f5b-5778-9afe-8cc45184846c") => ("SuiteSparse_jll", v"5.10.1+0")
  UUID("e66e0078-7015-5450-92f7-15fbd957f2ae") => ("CompilerSupportLibraries_jll", v"0.5.0+0")
  UUID("37e2e46d-f89d-539d-b4ee-838fcccc9c8e") => ("LinearAlgebra", nothing)
  UUID("ade2ca70-3891-5945-98fb-dc099432e06a") => ("Dates", nothing)
  UUID("9abbd945-dff8-562f-b5e8-e1ebf5ef1b79") => ("Profile", nothing)
  UUID("8e850b90-86db-534c-a0d3-1478176c7d93") => ("libblastrampoline_jll", v"3.1.0+0")
  UUID("3fa0cd96-eef1-5676-8a61-b3b8758bbffb") => ("REPL", nothing)
  UUID("781609d7-10c4-51f6-84f2-b8444358ff6d") => ("GMP_jll", v"6.2.1+1")
  UUID("0dad84c5-d112-42e6-8d28-ef12dabb789f") => ("ArgTools", v"1.1.1")
  UUID("4536629a-c528-5b80-bd46-f80d51c5b363") => ("OpenBLAS_jll", v"0.3.17+2")
  UUID("2f01184e-e22b-5df5-ae63-d93ebab69eaf") => ("SparseArrays", nothing)
  UUID("6462fe0b-24de-5631-8697-dd941f90decc") => ("Sockets", nothing)
  UUID("ca575930-c2e3-43a9-ace4-1e988b2c1908") => ("NetworkOptions", v"1.2.0")
  UUID("3a97d323-0669-5f0c-9066-3539efd106a3") => ("MPFR_jll", v"4.1.1+1")
  UUID("83775a58-1f1d-513f-b197-d71354ab007a") => ("Zlib_jll", v"1.2.12+1")
  UUID("29816b5a-b9ab-546f-933c-edad1886dfa8") => ("LibSSH2_jll", v"1.9.1+2")
  UUID("3f19e933-33d8-53b3-aaab-bd5110c3b7a0") => ("p7zip_jll", v"16.2.1+1")
  UUID("14a3606d-f60d-562e-9121-12d972cd8159") => ("MozillaCACerts_jll", v"2020.7.22")
  UUID("d6f4376e-aef5-505a-96c1-9c027394607a") => ("Markdown", nothing)
  UUID("f43a241f-c20a-4ad4-852c-f6b1247861c6") => ("Downloads", v"1.5.1")
  UUID("9fa8497b-333b-5362-9e8d-4d0656e87820") => ("Future", nothing)
  UUID("9a3f8284-a2c9-5f02-9a11-845980a1fd5c") => ("Random", nothing)
  UUID("8bb1440f-4735-579b-a4ab-409b98df4dab") => ("DelimitedFiles", nothing)
  UUID("deac9b47-8bc7-5906-a0fe-35ac56dc84c0") => ("LibCURL_jll", v"7.73.0+4")
  UUID("9e88b42a-f829-5b0c-bbe9-9e923198166b") => ("Serialization", nothing)
  UUID("47c5dbc3-30ba-59ef-96a6-123e260183d9") => ("LLVMLibUnwind_jll", v"12.0.1+0")
  UUID("4af54fe1-eca0-43a8-85a7-787d91b784e3") => ("LazyArtifacts", nothing)
  UUID("8dfed614-e22c-5e08-85e1-65c5234f0b40") => ("Test", nothing)
  UUID("10745b16-79ce-11e8-11f9-7d13ad32a3b2") => ("Statistics", nothing)
  UUID("fa267f1f-6049-4f14-aa54-33bafae1ed76") => ("TOML", v"1.0.0")
  UUID("b27032c2-a3e7-50c8-80cd-2d36dbcbfd21") => ("LibCURL", v"0.6.3")
  UUID("8ba89e20-285c-5b6f-9357-94700520ee1b") => ("Distributed", nothing)
  UUID("c8ffd9c3-330d-5841-b78e-0817d7145fa1") => ("MbedTLS_jll", v"2.24.0+2")
  UUID("56ddb016-857b-54e1-b83d-db4d58db5568") => ("Logging", nothing)
  UUID("1a1011a3-84de-559e-8e89-a11a2f7dc383") => ("SharedArrays", nothing)
  UUID("4607b0f0-06f3-5cda-b6b1-a6196a1729e9") => ("SuiteSparse", nothing)
  UUID("8e850ede-7688-5339-a07c-302acd2aaf8d") => ("nghttp2_jll", v"1.41.0+1")
  UUID("cf7118a7-6976-5b1a-9a39-7adc72f591a4") => ("UUIDs", nothing)
  UUID("4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5") => ("Unicode", nothing)
  UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f") => ("Pkg", v"1.8.0")
  UUID("de0858da-6303-5e67-8744-51eddeeeb8d7") => ("Printf", nothing)
  UUID("a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e") => ("Tar", v"1.10.0")
  UUID("8f36deef-c2a5-5394-99ed-8e07531fb29a") => ("libLLVM_jll", v"12.0.1+4")
  UUID("ea8e919c-243c-51af-8825-aaa63cd721ce") => ("SHA", v"0.7.0")
  UUID("8f399da3-3557-5675-b5ff-fb832c97cbdb") => ("Libdl", nothing)
  UUID("183b4373-6708-53ba-ad28-60e28bb38547") => ("LibUV_jll", v"2.0.1+4")
```
Which caused test failures, as instead of `"LinearAlgebra"`, we'd have (for example) `("LinearAlgebra", nothing)` in our `setdiff` instead of `LinearAlgebra`, resulting in the stdlibs no longer successfully being filtered out.