### PR TITLE
Fix `UndefVarError` in Julia v1.0-1.3

### DIFF
--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -195,8 +195,10 @@ function test_ambiguities_impl(
         println("Ambiguity #", i)
         println(m1)
         println(m2)
-        ambiguity_hint(m1, m2)
-        println()
+        @static if isdefined(Base, :morespecific)
+            ambiguity_hint(m1, m2)
+            println()
+        end
         println()
     end
     return ambiguities == []


### PR DESCRIPTION
Ref: https://github.com/JuliaTesting/Aqua.jl/pull/71/files#r834842406.  If you have better ideas about how to more proper fix this or how to actually test this code path which is clearly untested, please take over this PR or open a new one, but at least this doesn't break the package in older versions of Julia.  Not very useful to have a QUality Assurance package that breaks your tests.

CC:  @Roger-luo