### PR TITLE
do not trigger deprecation warnings

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1,8 +1,9 @@
 function walkmodules(f, x::Module)
     f(x)
-    for n in names(x; all = true)
-        # `getproperty` triggers deprecation warnings
-        if !Base.isdeprecated(x, n) && isdefined(x, n)
+    for n in names(x; all = true, imported = true)
+        # `isdefined` and `getproperty` can trigger deprecation warnings
+        if Base.isbindingresolved(x, n) && !Base.isdeprecated(x, n)
+            isdefined(x, n) || continue
             y = getproperty(x, n)
             if y isa Module && y !== x && parentmodule(y) === x
                 walkmodules(f, y)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1,6 +1,6 @@
 function walkmodules(f, x::Module)
     f(x)
-    for n in names(x; all=true)
+    for n in names(x; all = true)
         # `isdefined` and `getproperty` can trigger deprecation warnings
         if Base.isbindingresolved(x, n) && !Base.isdeprecated(x, n)
             isdefined(x, n) || continue

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1,7 +1,8 @@
 function walkmodules(f, x::Module)
     f(x)
-    for n in names(x; all=true)
-        if isdefined(x, n)
+    for n in names(x; all = true)
+        # `getproperty` triggers deprecation warnings
+        if !Base.isdeprecated(x, n) && isdefined(x, n)
             y = getproperty(x, n)
             if y isa Module && y !== x && parentmodule(y) === x
                 walkmodules(f, y)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1,6 +1,6 @@
 function walkmodules(f, x::Module)
     f(x)
-    for n in names(x; all = true, imported = true)
+    for n in names(x; all=true)
         # `isdefined` and `getproperty` can trigger deprecation warnings
         if Base.isbindingresolved(x, n) && !Base.isdeprecated(x, n)
             isdefined(x, n) || continue


### PR DESCRIPTION
`getproperty` triggers deprecation warnings: avoid triggering those when walking modules.

Fix https://github.com/JuliaTesting/Aqua.jl/issues/83.

Also observed in the `UnicodePlots` [test suite](https://github.com/JuliaPlots/UnicodePlots.jl/actions/runs/3465118212/jobs/5787474874#step:6:337), unfortunately this PR only fixes `GeometryBasics` tests mentioned in the issue, we also need a PR in `Reexports.jl` or `Colors.jl`.