### PR TITLE
Add `Aqua.Piracy` to autodocs block

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,7 @@ Private = false
 ```
 
 ```@autodocs
-Modules = [Aqua]
+Modules = [Aqua, Aqua.Piracy]
 Public = false
 Filter = t -> startswith(String(nameof(t)), "test_")
 ```

--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -138,6 +138,7 @@ end
     test_piracy(m::Module)
 
 Test that `m` does not commit type piracy.
+See [Julia documentation](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy) for more information about type piracy.
 """
 function test_piracy(m::Module)
     @test hunt(m) == Method[]


### PR DESCRIPTION
This PR fixes https://github.com/JuliaTesting/Aqua.jl/issues/94.