### PR TITLE
Check for piracy against Base by default

### DIFF
--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -35,13 +35,16 @@ function all_methods!(
     result
 end
 
-function all_methods(mod::Module; filter_default::Bool = true)
+function all_methods(mod::Module; filter_default::Bool = true, include_base::Bool = true)
     result = Method[]
     done_callables = Base.IdSet()
     walkmodules(mod) do mod
         all_methods!(mod, done_callables, result, filter_default)
     end
-    return result
+    # Base may not be reachable from walkmodules, but needs to be checked,
+    # since it's one of the most common targets of piracy
+    include_base && all_methods!(Base, done_callables, result, filter_default)
+    result
 end
 
 ##################################

--- a/test/test_piracy.jl
+++ b/test/test_piracy.jl
@@ -33,10 +33,6 @@ Base.findlast(::Val{:foo}, x::Int) = x + 1
 Base.findfirst(::Set{Vector{Char}}, ::Int) = 1
 Base.findfirst(::Union{Foo,Bar{Set{Unsigned}},UInt}, ::Tuple{Vararg{String}}) = 1
 Base.findfirst(::AbstractChar, ::Set{T}) where {Int <: T <: Integer} = 1
-
-# Assign them names in this module so they can be found by all_methods
-x = Base.findfirst
-y = Base.findlast
 end # PiracyModule
 
 using Aqua: Piracy


### PR DESCRIPTION
Previously, libraries which pirated Base, but did not manually bring the offending function into scope was not detected.
Now, default to checking Base for being a victim of piracy by default.

Edit: CI "fails" due to codecoverage acting up.