### PR TITLE
Check `docs/Project.toml` as well, if it exists

### DIFF
--- a/src/project_toml_formatting.jl
+++ b/src/project_toml_formatting.jl
@@ -21,6 +21,8 @@ function project_toml_files_in(pkg::PkgId)
     end
     dir = dirname(dirname(srcpath))
     paths = [project_toml_path(dir)[1]]
+    p, found = project_toml_path(joinpath(dir, "docs"))
+    found && push!(paths, p)
     p, found = project_toml_path(joinpath(dir, "test"))
     found && push!(paths, p)
     return paths


### PR DESCRIPTION
Currently, only `Project.toml` and `test/Project.toml` are checked for their formatting. This PR adds the same check for `docs/Project.toml`, if that file exists.

Resolves #51.