### PR TITLE
Add kwarg `broken`

### DIFF
--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -138,8 +138,8 @@ function test_all(
         end
     end
     @testset "Piracy" begin
-        if piracy
-            test_piracy(testtarget)
+        if piracy !== false
+            test_piracy(testtarget; askwargs(piracy)...)
         end
     end
 end

--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -7,6 +7,8 @@ calls `Test.detect_ambiguities` in a separated clean process to avoid
 false-positive.
 
 # Keyword Arguments
+- `broken::Bool = false`: If true, it uses `@test_broken` instead of
+  `@test`.
 - `color::Union{Bool, Nothing} = nothing`: Enable/disable colorful
   output if a `Bool`.  `nothing` (default) means to inherit the
   setting in the current process.
@@ -91,6 +93,7 @@ function _test_ambiguities(
     packages::Vector{PkgId};
     color::Union{Bool, Nothing} = nothing,
     exclude::AbstractArray = [],
+    broken::Bool = false,
     # Options to be passed to `Test.detect_ambiguities`:
     detect_ambiguities_options...,
 )
@@ -114,7 +117,11 @@ function _test_ambiguities(
         cmd = `$cmd --color=yes`
     end
     cmd = `$cmd --startup-file=no -e $code`
-    @test success(pipeline(cmd; stdout=stdout, stderr=stderr))
+    if broken
+        @test_broken success(pipeline(cmd; stdout=stdout, stderr=stderr))
+    else
+        @test success(pipeline(cmd; stdout=stdout, stderr=stderr))
+    end
 end
 
 function reprpkgids(packages::Vector{PkgId})

--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -91,7 +91,7 @@ end
 
 function _test_ambiguities(
     packages::Vector{PkgId};
-    color::Union{Bool, Nothing} = nothing,
+    color::Union{Bool,Nothing} = nothing,
     exclude::AbstractArray = [],
     broken::Bool = false,
     # Options to be passed to `Test.detect_ambiguities`:
@@ -118,9 +118,9 @@ function _test_ambiguities(
     end
     cmd = `$cmd --startup-file=no -e $code`
     if broken
-        @test_broken success(pipeline(cmd; stdout=stdout, stderr=stderr))
+        @test_broken success(pipeline(cmd; stdout = stdout, stderr = stderr))
     else
-        @test success(pipeline(cmd; stdout=stdout, stderr=stderr))
+        @test success(pipeline(cmd; stdout = stdout, stderr = stderr))
     end
 end
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -29,7 +29,15 @@ end
     test_undefined_exports(module::Module)
 
 Test that all `export`ed names in `module` actually exist.
+
+# Keyword Arguments
+- `broken::Bool = false`: If true, it uses `@test_broken` instead of
+  `@test`.
 """
-function test_undefined_exports(m::Module)
-    @test undefined_exports(m) == []
+function test_undefined_exports(m::Module; broken::Bool = false)
+    if broken
+        @test_broken undefined_exports(m) == []
+    else
+        @test undefined_exports(m) == []
+    end
 end

--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -1,6 +1,6 @@
 module Piracy
 
-using Test: @test
+using Test: @test, @test_broken
 using ..Aqua: walkmodules
 
 const DEFAULT_PKGS = (Base.PkgId(Base), Base.PkgId(Core))
@@ -139,8 +139,12 @@ end
 
 Test that `m` does not commit type piracy.
 See [Julia documentation](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy) for more information about type piracy.
+
+# Keyword Arguments
+- `broken::Bool = false`: If true, it uses `@test_broken` instead of
+  `@test`.
 """
-function test_piracy(m::Module)
+function test_piracy(m::Module; broken::Bool = false)
     v = hunt(m)
     if !isempty(v)
         printstyled(
@@ -152,7 +156,11 @@ function test_piracy(m::Module)
         show(stderr, MIME"text/plain"(), v)
         println(stderr)
     end
-    @test isempty(v)
+    if broken
+        @test_broken isempty(v)
+    else
+        @test isempty(v)
+    end
 end
 
 end # module

--- a/src/stale_deps.jl
+++ b/src/stale_deps.jl
@@ -17,7 +17,6 @@ Test that `package` loads all dependencies listed in `Project.toml`.
 # Keyword Arguments
 - `ignore::Vector{Symbol}`: names of dependent packages to be ignored.
 """
-test_stale_deps
 function test_stale_deps(packages; kwargs...)
     @testset "$(result.label)" for result in analyze_stale_deps(packages, kwargs)
         @debug result.label result

--- a/src/unbound_args.jl
+++ b/src/unbound_args.jl
@@ -3,8 +3,12 @@
 
 Test that all methods in `module` and its submodules do not have
 unbound type parameter.
+
+# Keyword Arguments
+- `broken::Bool = false`: If true, it uses `@test_broken` instead of
+  `@test`.
 """
-function test_unbound_args(m::Module)
+function test_unbound_args(m::Module; broken::Bool = false)
     unbounds = detect_unbound_args_recursively(m)
     if !isempty(unbounds)
         @warn (
@@ -20,7 +24,11 @@ function test_unbound_args(m::Module)
             println(stderr)
         end
     end
-    @test isempty(unbounds)
+    if broken
+        @test_broken isempty(unbounds)
+    else
+        @test isempty(unbounds)
+    end
 end
 
 # There used to be a bug in `Test.detect_unbound_args` when used on


### PR DESCRIPTION
Resolves https://github.com/JuliaTesting/Aqua.jl/issues/109.

This adds a `broken` kwarg (default `false`) to the tests `ambiguities`, `exports`, `piracy`, and `unbound_args`.
For the other tests it a lot harder to do as the tests are executed in a loop, and, after thinking some more about it, a lot less sensible after all.