### PR TITLE
Remove support for 0.4.x & 0.5.x series

### DIFF
--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -65,22 +65,22 @@ passed to `\$x` to specify the keyword arguments for `test_\$x`.
 - `ambiguities = true`
 - `unbound_args = true`
 - `undefined_exports = true`
-- `piracy = true`
 - `project_extras = true`
 - `stale_deps = true`
 - `deps_compat = true`
 - `project_toml_formatting = true`
+- `piracy = true`
 """
 function test_all(
     testtarget::Module;
     ambiguities = true,
     unbound_args = true,
     undefined_exports = true,
-    piracy = true,
     project_extras = true,
     stale_deps = true,
     deps_compat = true,
     project_toml_formatting = true,
+    piracy = true,
 )
     @testset "Method ambiguity" begin
         if ambiguities !== false

--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -15,17 +15,6 @@ catch
     import Compat
 end
 
-const AQUA_VERSION = let path = joinpath(dirname(@__DIR__), "Project.toml")
-    proj = TOML.parsefile(path)
-    include_dependency(path)
-    VersionNumber(proj["version"])
-end
-
-_lt05(y::AbstractString, n::AbstractString = "") = AQUA_VERSION < v"0.5-" ? y : n
-_ge05(y::AbstractString, n::AbstractString = "") = AQUA_VERSION >= v"0.5-" ? y : n
-_lt06(y::AbstractString, n::AbstractString = "") = AQUA_VERSION < v"0.6-" ? y : n
-_ge06(y::AbstractString, n::AbstractString = "") = AQUA_VERSION >= v"0.6-" ? y : n
-
 include("pkg/Versions.jl")
 using .Versions: VersionSpec, semver_spec
 
@@ -46,15 +35,14 @@ using .Piracy: test_piracy
 
 Run following tests in isolated testset:
 
-* [`test_ambiguities([testtarget, Base$(_ge05(", Core"))])`](@ref test_ambiguities)
+* [`test_ambiguities([testtarget, Base, Core])`](@ref test_ambiguities)
 * [`test_unbound_args(testtarget)`](@ref test_unbound_args)
 * [`test_undefined_exports(testtarget)`](@ref test_undefined_exports)
 * [`test_piracy(testtarget)`](@ref test_piracy)
-* [`test_project_extras(testtarget)`](@ref test_project_extras) $(_lt05("(optional)"))
-* [`test_stale_deps(testtarget)`](@ref test_stale_deps) $(_lt05("(optional)"))
-* [`test_deps_compat(testtarget)`](@ref test_deps_compat) $(_lt05("(optional)"))
+* [`test_project_extras(testtarget)`](@ref test_project_extras)
+* [`test_stale_deps(testtarget)`](@ref test_stale_deps)
+* [`test_deps_compat(testtarget)`](@ref test_deps_compat)
 * [`test_project_toml_formatting(testtarget)`](@ref test_project_toml_formatting)
-  $(_lt05("(optional)"))
 
 !!! compat "Aqua.jl 0.5"
 
@@ -77,22 +65,22 @@ passed to `\$x` to specify the keyword arguments for `test_\$x`.
 - `ambiguities = true`
 - `unbound_args = true`
 - `undefined_exports = true`
-- `piracy = $(_lt06("false", "true"))`
-- `project_extras = $(_lt05("false", "true"))`
-- `stale_deps = $(_lt05("false", "true"))`
-- `deps_compat = $(_lt05("false", "true"))`
-- `project_toml_formatting = $(_lt05("false", "true"))`
+- `piracy = true`
+- `project_extras = true`
+- `stale_deps = true`
+- `deps_compat = true`
+- `project_toml_formatting = true`
 """
 function test_all(
     testtarget::Module;
     ambiguities = true,
     unbound_args = true,
     undefined_exports = true,
-    piracy = AQUA_VERSION >= v"0.6-",
-    project_extras = AQUA_VERSION >= v"0.5-",
-    stale_deps = AQUA_VERSION >= v"0.5-",
-    deps_compat = AQUA_VERSION >= v"0.5-",
-    project_toml_formatting = AQUA_VERSION >= v"0.5-",
+    piracy = true,
+    project_extras = true,
+    stale_deps = true,
+    deps_compat = true,
+    project_toml_formatting = true,
 )
     @testset "Method ambiguity" begin
         if ambiguities !== false
@@ -100,10 +88,8 @@ function test_all(
                 # Maybe remove this branch?
                 @warn "Ignoring ambiguities from `Base` to workaround JuliaLang/julia#36962"
                 test_ambiguities([testtarget]; askwargs(ambiguities)...)
-            elseif AQUA_VERSION >= v"0.5-"
-                test_ambiguities([testtarget, Base, Core]; askwargs(ambiguities)...)
             else
-                test_ambiguities([testtarget, Base]; askwargs(ambiguities)...)
+                test_ambiguities([testtarget, Base, Core]; askwargs(ambiguities)...)
             end
         end
     end


### PR DESCRIPTION
The only difference are the default values for certain keyword
arguments. Anyone using Aqua can easily pass different values
for these without the need of additional Aqua versions.
