### PR TITLE
Fix `getobj` for parameterized callable objects

### DIFF
--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -150,7 +150,7 @@ struct _NoValue end
 # FIXME: This does not support non-singleton callables.
 function getobj(m::Method)
     ty = try
-        Base.tuple_type_head(m.sig)
+        fieldtype(m.sig, 1)
     catch err
         @error(
             "Failed to obtain a function from `Method`.",
@@ -160,6 +160,7 @@ function getobj(m::Method)
         # too much compared to what it is now.  So, bailing out.
         return _NoValue()
     end
+    ty = Base.unwrap_unionall(ty)
     try
         return ty.instance  # this should work for singletons (e.g., functions)
     catch

--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -144,10 +144,7 @@ end
 function is_pirate(meth::Method)
     method_pkg = Base.PkgId(meth.module)
 
-    signature = meth.sig
-    while signature isa UnionAll
-        signature = signature.body
-    end
+    signature = Base.unwrap_unionall(meth.sig)
 
     # the first parameter in the signature is the function type, and it
     # follows slightly other rules if it happens to be a Union type

--- a/test/pkgs/PkgWithAmbiguities.jl
+++ b/test/pkgs/PkgWithAmbiguities.jl
@@ -3,9 +3,11 @@ module PkgWithAmbiguities
 f(::Any, ::Int) = 1
 f(::Int, ::Any) = 2
 
-abstract type AbstractType{T} end
-struct ConcreteType{T} <: AbstractType{T} end
-(::AbstractType{T})(::Tuple{Tuple{Int}}) where {T} = 1
-(::ConcreteType)(::Tuple) = 2
+@static if VERSION >= v"1.3-"
+    abstract type AbstractType{T} end
+    struct ConcreteType{T} <: AbstractType{T} end
+    (::AbstractType{T})(::Tuple{Tuple{Int}}) where {T} = 1
+    (::ConcreteType)(::Tuple) = 2
+end
 
 end  # module

--- a/test/pkgs/PkgWithAmbiguities.jl
+++ b/test/pkgs/PkgWithAmbiguities.jl
@@ -3,4 +3,9 @@ module PkgWithAmbiguities
 f(::Any, ::Int) = 1
 f(::Int, ::Any) = 2
 
+abstract type AbstractType{T} end
+struct ConcreteType{T} <: AbstractType{T} end
+(::AbstractType{T})(::Tuple{Tuple{Int}}) where {T} = 1
+(::ConcreteType)(::Tuple) = 2
+
 end  # module

--- a/test/test_ambiguities.jl
+++ b/test/test_ambiguities.jl
@@ -5,13 +5,23 @@ include("preamble.jl")
 using PkgWithAmbiguities
 
 @testset begin
-    @info "↓↓↓ Following failures are expected. ↓↓↓"
     results = @testtestset begin
+        @info "↓↓↓ Following failures are expected. ↓↓↓"
         Aqua.test_ambiguities(PkgWithAmbiguities)
+
+        # exclude just anything irrelevant, see #49
+        Aqua.test_ambiguities(PkgWithAmbiguities; exclude = [convert])
+
+        Aqua.test_ambiguities(
+            PkgWithAmbiguities;
+            exclude = [PkgWithAmbiguities.f, PkgWithAmbiguities.AbstractType],
+        )
+        @info "↑↑↑ Above failures are expected. ↑↑↑" # move above once broken test fixed
     end
-    @info "↑↑↑ Above failures are expected. ↑↑↑"
-    @test length(results) == 1
+    @test length(results) == 3
     @test results[1] isa Test.Fail
+    @test results[2] isa Test.Fail
+    @test_broken results[3] isa Test.Pass
 
     # It works with other tests:
     Aqua.test_unbound_args(PkgWithAmbiguities)

--- a/test/test_ambiguities.jl
+++ b/test/test_ambiguities.jl
@@ -5,23 +5,33 @@ include("preamble.jl")
 using PkgWithAmbiguities
 
 @testset begin
-    results = @testtestset begin
-        @info "↓↓↓ Following failures are expected. ↓↓↓"
-        Aqua.test_ambiguities(PkgWithAmbiguities)
+    @static if VERSION >= v"1.3-"
+        results = @testtestset begin
+            @info "↓↓↓ Following failures are expected. ↓↓↓"
+            Aqua.test_ambiguities(PkgWithAmbiguities)
 
-        # exclude just anything irrelevant, see #49
-        Aqua.test_ambiguities(PkgWithAmbiguities; exclude = [convert])
+            # exclude just anything irrelevant, see #49
+            Aqua.test_ambiguities(PkgWithAmbiguities; exclude = [convert])
 
-        Aqua.test_ambiguities(
-            PkgWithAmbiguities;
-            exclude = [PkgWithAmbiguities.f, PkgWithAmbiguities.AbstractType],
-        )
-        @info "↑↑↑ Above failures are expected. ↑↑↑" # move above once broken test fixed
+            Aqua.test_ambiguities(
+                PkgWithAmbiguities;
+                exclude = [PkgWithAmbiguities.f, PkgWithAmbiguities.AbstractType],
+            )
+            @info "↑↑↑ Above failures are expected. ↑↑↑" # move above once broken test fixed
+        end
+        @test length(results) == 3
+        @test results[1] isa Test.Fail
+        @test results[2] isa Test.Fail
+        @test_broken results[3] isa Test.Pass
+    else
+        results = @testtestset begin
+            @info "↓↓↓ Following failures are expected. ↓↓↓"
+            Aqua.test_ambiguities(PkgWithAmbiguities)
+            @info "↑↑↑ Above failures are expected. ↑↑↑"
+        end
+        @test length(results) == 1
+        @test results[1] isa Test.Fail
     end
-    @test length(results) == 3
-    @test results[1] isa Test.Fail
-    @test results[2] isa Test.Fail
-    @test_broken results[3] isa Test.Pass
 
     # It works with other tests:
     Aqua.test_unbound_args(PkgWithAmbiguities)


### PR DESCRIPTION
Fixes https://github.com/JuliaTesting/Aqua.jl/issues/49 and fixes https://github.com/JuliaTesting/Aqua.jl/issues/141.

The main change is the unwrapping of `UnionAll`s in `getobj`. While looking through it, I furthermore used it in the piracy tests as well (where until now the function was basically inlined). And in `getobj` the deprecated function `tuple_type_head` was used, the alternative is `fieldtype(-, 1)`. Both changes have been tested in julia 1.0, 1.6 and 1.9.

The MWE in https://github.com/JuliaTesting/Aqua.jl/issues/49#issue-711726567 by @mtsch for julia 1.0 (`Aqua.test_ambiguities([MWE, Base, Core], exclude=[convert])`) reports precisely the same 52 ambiguities (up to order) as with the current master, but there are no errors. 

The much smaller MWE in https://github.com/JuliaTesting/Aqua.jl/issues/49#issuecomment-1576304828 by @fingolfin  for julia 1.9 no longer fails.

Please check if this fixes it for you as well.