### PR TITLE
Refactor `ambiguities.jl`

### DIFF
--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -36,7 +36,7 @@ aspkgids(packages) = mapfoldl(aspkgid, push!, packages, init = PkgId[])
 aspkgid(pkg::PkgId) = pkg
 function aspkgid(m::Module)
     if !ispackage(m)
-        error("Non-package (non-toplevel) module is not supported.", " Got: $m")
+        error("Non-package (non-toplevel) module is not supported. Got: $m")
     end
     return PkgId(m)
 end
@@ -244,10 +244,8 @@ function ambiguity_hint(m1::Method, m2::Method)
             else
                 println()
                 print(
-                    "To resolve the ambiguity, try making one of the methods more specific, or ",
-                )
-                print(
-                    "adding a new method more specific than any of the existing applicable methods.",
+                    """To resolve the ambiguity, try making one of the methods more specific, or 
+                    adding a new method more specific than any of the existing applicable methods.""",
                 )
             end
         end

--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -72,7 +72,7 @@ function normalize_and_check_exclude(exclude::AbstractVector)
     exspecs = mapfoldl(normalize_exclude, push!, exclude, init = ExcludeSpec[])
     for (spec, obj) in zip(exspecs, exclude)
         if getobj(spec) !== obj
-            error("Name `$str` is resolved to a different object.")
+            error("Name `$(spec[2])` is resolved to a different object.")
         end
     end
     return exspecs::Vector{ExcludeSpec}

--- a/test/test_ambiguities.jl
+++ b/test/test_ambiguities.jl
@@ -6,31 +6,28 @@ using PkgWithAmbiguities
 
 @testset begin
     @static if VERSION >= v"1.3-"
-        results = @testtestset begin
-            @info "↓↓↓ Following failures are expected. ↓↓↓"
-            Aqua.test_ambiguities(PkgWithAmbiguities)
+        num_ambiguities, strout, strerr =
+            Aqua._find_ambiguities(Aqua.aspkgids(PkgWithAmbiguities))
+        @test num_ambiguities == 2
+        @test isempty(strerr)
 
-            # exclude just anything irrelevant, see #49
-            Aqua.test_ambiguities(PkgWithAmbiguities; exclude = [convert])
+        # exclude just anything irrelevant, see #49
+        num_ambiguities, strout, strerr =
+            Aqua._find_ambiguities(Aqua.aspkgids(PkgWithAmbiguities); exclude = [convert])
+        @test num_ambiguities == 2
+        @test isempty(strerr)
 
-            Aqua.test_ambiguities(
-                PkgWithAmbiguities;
-                exclude = [PkgWithAmbiguities.f, PkgWithAmbiguities.AbstractType],
-            )
-            @info "↑↑↑ Above failures are expected. ↑↑↑" # move above once broken test fixed
-        end
-        @test length(results) == 3
-        @test results[1] isa Test.Fail
-        @test results[2] isa Test.Fail
-        @test_broken results[3] isa Test.Pass
+        num_ambiguities, strout, strerr = Aqua._find_ambiguities(
+            Aqua.aspkgids(PkgWithAmbiguities);
+            exclude = [PkgWithAmbiguities.f, PkgWithAmbiguities.AbstractType],
+        )
+        @test_broken num_ambiguities == 0
+        @test isempty(strerr)
     else
-        results = @testtestset begin
-            @info "↓↓↓ Following failures are expected. ↓↓↓"
-            Aqua.test_ambiguities(PkgWithAmbiguities)
-            @info "↑↑↑ Above failures are expected. ↑↑↑"
-        end
-        @test length(results) == 1
-        @test results[1] isa Test.Fail
+        num_ambiguities, strout, strerr =
+            Aqua._find_ambiguities(Aqua.aspkgids(PkgWithAmbiguities))
+        @test num_ambiguities == 1
+        @test isempty(strerr)
     end
 
     # It works with other tests:


### PR DESCRIPTION
Changes:

- Formatting, it annoys me every time I want to change something that I cannot run the autoformatter
- Parse the output of `test_ambiguities_impl` to allow better testing (number of ambiguities and errors inside `getobj`)
- Adapt the tests