### PR TITLE
Enhance `test_ambiguities`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Aqua"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
-version = "0.6.4-DEV"
+version = "0.7.0-DEV"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -15,10 +15,9 @@ false-positive.
 - `exclude::AbstractVector = []`: A vector of functions or types to be
   excluded from ambiguity testing.  A function means to exclude _all_
   its methods.  A type means to exclude _all_ its methods of the
-  callable (sometimes also called "functor").  That is to say,
-  `MyModule.MyType` means to ignore ambiguities between `(::MyType)(x,
-  y::Int)` and `(::MyType)(x::Int, y)`.  Note that there is no way to
-  exclude the constructor of a specific type at the moment.
+  callable (sometimes also called "functor") and the constructor.  
+  That is to say, `MyModule.MyType` means to ignore ambiguities between 
+  `(::MyType)(x, y::Int)` and `(::MyType)(x::Int, y)`.
 - `recursive::Bool = true`: Passed to `Test.detect_ambiguities`.
   Note that the default here (`true`) is different from
   `detect_ambiguities`.  This is for testing ambiguities in methods
@@ -165,7 +164,6 @@ end
 
 struct _NoValue end
 
-# FIXME: This does not support non-singleton callables.
 function getobj(m::Method)
     ty = try
         fieldtype(m.sig, 1)
@@ -179,13 +177,17 @@ function getobj(m::Method)
         return _NoValue()
     end
     ty = Base.unwrap_unionall(ty)
-    try
-        return ty.instance  # this should work for singletons (e.g., functions)
-    catch
+    if ty <: Function
+        try
+            return ty.instance  # this should work for functions
+        catch
+        end
     end
     try
         if ty.name.wrapper === Type
             return ty.parameters[1]
+        else
+            return ty.name.wrapper
         end
     catch err
         @error(
@@ -208,8 +210,7 @@ function test_ambiguities_impl(
     if !isempty(exspecs)
         exclude_objs = getobj.(exspecs)
         ambiguities = filter(ambiguities) do (m1, m2)
-            # `getobj(m1) == getobj(m2)` so no need to check `m2`
-            getobj(m1) ∉ exclude_objs
+            getobj(m1) ∉ exclude_objs && getobj(m2) ∉ exclude_objs
         end
     end
 

--- a/test/pkgs/PkgWithAmbiguities.jl
+++ b/test/pkgs/PkgWithAmbiguities.jl
@@ -1,13 +1,40 @@
 module PkgWithAmbiguities
 
+# 1 ambiguity
 f(::Any, ::Int) = 1
 f(::Int, ::Any) = 2
 
+abstract type AbstractType end
+struct SingletonType <: AbstractType end
+
+struct ConcreteType <: AbstractType
+    x::Int
+end
+
+# 2 ambiguities
+SingletonType(::Any, ::Any, ::Int) = 1
+SingletonType(::Any, ::Int, ::Int) = 2
+SingletonType(::Int, ::Any, ::Any) = 3
+
+# 1 ambiguity
+(::SingletonType)(::Any, ::Float64) = 1
+(::SingletonType)(::Float64, ::Any) = 2
+
+# 3 ambiguities
+ConcreteType(::Any, ::Any, ::Int) = 1
+ConcreteType(::Any, ::Int, ::Any) = 2
+ConcreteType(::Int, ::Any, ::Any) = 3
+
+# 1 ambiguity
+(::ConcreteType)(::Any, ::Float64) = 1
+(::ConcreteType)(::Float64, ::Any) = 2
+
+
 @static if VERSION >= v"1.3-"
-    abstract type AbstractType{T} end
-    struct ConcreteType{T} <: AbstractType{T} end
-    (::AbstractType{T})(::Tuple{Tuple{Int}}) where {T} = 1
-    (::ConcreteType)(::Tuple) = 2
+    abstract type AbstractParameterizedType{T} end
+    struct ConcreteParameterizedType{T} <: AbstractParameterizedType{T} end
+    (::AbstractParameterizedType{T})(::Tuple{Tuple{Int}}) where {T} = 1
+    (::ConcreteParameterizedType)(::Tuple) = 2
 end
 
 end  # module

--- a/test/test_ambiguities.jl
+++ b/test/test_ambiguities.jl
@@ -5,30 +5,65 @@ include("preamble.jl")
 using PkgWithAmbiguities
 
 @testset begin
-    @static if VERSION >= v"1.3-"
-        num_ambiguities, strout, strerr =
-            Aqua._find_ambiguities(Aqua.aspkgids(PkgWithAmbiguities))
-        @test num_ambiguities == 2
-        @test isempty(strerr)
-
-        # exclude just anything irrelevant, see #49
-        num_ambiguities, strout, strerr =
-            Aqua._find_ambiguities(Aqua.aspkgids(PkgWithAmbiguities); exclude = [convert])
-        @test num_ambiguities == 2
-        @test isempty(strerr)
-
-        num_ambiguities, strout, strerr = Aqua._find_ambiguities(
-            Aqua.aspkgids(PkgWithAmbiguities);
-            exclude = [PkgWithAmbiguities.f, PkgWithAmbiguities.AbstractType],
-        )
-        @test_broken num_ambiguities == 0
-        @test isempty(strerr)
-    else
-        num_ambiguities, strout, strerr =
-            Aqua._find_ambiguities(Aqua.aspkgids(PkgWithAmbiguities))
-        @test num_ambiguities == 1
+    function check_testcase(exclude, num_ambiguities::Int; broken::Bool = false)
+        num_ambiguities_, strout, strerr =
+            Aqua._find_ambiguities(Aqua.aspkgids(PkgWithAmbiguities); exclude = exclude)
+        if broken
+            @test_broken num_ambiguities_ == num_ambiguities
+        else
+            @test num_ambiguities_ == num_ambiguities
+        end
         @test isempty(strerr)
     end
+
+    @static if VERSION >= v"1.3-"
+        total = 9
+    else
+        total = 8
+    end
+
+    check_testcase([], total)
+
+    # exclude just anything irrelevant, see #49
+    check_testcase([convert], total)
+
+    # exclude function
+    check_testcase([PkgWithAmbiguities.f], total - 1)
+
+    # exclude callables and constructors
+    check_testcase([PkgWithAmbiguities.SingletonType], total - 2 - 1)
+    check_testcase([PkgWithAmbiguities.ConcreteType], total - 3 - 1)
+
+    # exclude abstract supertype without callables and constructors
+    check_testcase([PkgWithAmbiguities.AbstractType], total)
+
+    @static if VERSION >= v"1.3-"
+        # for ambiguities between abstract and concrete type callables, only one needs to be excluded
+        check_testcase([PkgWithAmbiguities.AbstractParameterizedType], total - 1)
+        check_testcase([PkgWithAmbiguities.ConcreteParameterizedType], total - 1)
+
+        # exclude everything
+        check_testcase(
+            [
+                PkgWithAmbiguities.f,
+                PkgWithAmbiguities.SingletonType,
+                PkgWithAmbiguities.ConcreteType,
+                PkgWithAmbiguities.ConcreteParameterizedType,
+            ],
+            0,
+        )
+    else
+        # exclude everything
+        check_testcase(
+            [
+                PkgWithAmbiguities.f,
+                PkgWithAmbiguities.SingletonType,
+                PkgWithAmbiguities.ConcreteType,
+            ],
+            0,
+        )
+    end
+
 
     # It works with other tests:
     Aqua.test_unbound_args(PkgWithAmbiguities)

--- a/test/test_ambiguities.jl
+++ b/test/test_ambiguities.jl
@@ -6,8 +6,8 @@ using PkgWithAmbiguities
 
 @testset begin
     function check_testcase(exclude, num_ambiguities::Int; broken::Bool = false)
-        num_ambiguities_, strout, strerr =
-            Aqua._find_ambiguities(Aqua.aspkgids(PkgWithAmbiguities); exclude = exclude)
+        pkgids = Aqua.aspkgids([PkgWithAmbiguities, Core]) # include Core to find constructor ambiguities
+        num_ambiguities_, strout, strerr = Aqua._find_ambiguities(pkgids; exclude = exclude)
         if broken
             @test_broken num_ambiguities_ == num_ambiguities
         else


### PR DESCRIPTION
As written in the removed comment, `test_ambiguities` does not allow non-singleton callable in `exclude`. This is working now.
I furthermore changed the behavior for singleton callables to be the same. And I introduced constructors for `exclude`.
Unfortunately, one can only exclude the constructor of type `MyType` and all callables of `MyType` simultaneously, or none of both.

For my convenience, this already includes the changes of https://github.com/JuliaTesting/Aqua.jl/pull/143.

This change is probably breaking, semi-documented behavior of `exclude` for `test_ambiguities`. I thus bumped the version.