### PR TITLE
Make piracy tests slightly more efficient

### DIFF
--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -150,7 +150,7 @@ function is_pirate(meth::Method)
     # follows slightly other rules if it happens to be a Union type
     is_foreign_method(signature.parameters[1], method_pkg) || return false
 
-    all(param -> is_foreign(param, method_pkg), signature.parameters)
+    all(param -> is_foreign(param, method_pkg), signature.parameters[2:end])
 end
 
 hunt(mod::Module; from::Module = mod) = hunt(Base.PkgId(mod); from = from)


### PR DESCRIPTION
Followup to #131 (mentioned in https://github.com/JuliaTesting/Aqua.jl/pull/131#discussion_r1237021083).

The first parameter (the function type) is already checked prior. So currently, it is checked twice, which is not needed and may be confusing in the future when changing the semantics of `is_foreign_method` and `is_foreign`.