### PR TITLE
Remove special branch for some julia v1.6.0-DEV versions

### DIFF
--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -82,13 +82,7 @@ function test_all(
 )
     @testset "Method ambiguity" begin
         if ambiguities !== false
-            if v"1.6.0-DEV.816" <= VERSION < v"1.6.0-DEV.875"
-                # Maybe remove this branch?
-                @warn "Ignoring ambiguities from `Base` to workaround JuliaLang/julia#36962"
-                test_ambiguities([testtarget]; askwargs(ambiguities)...)
-            else
-                test_ambiguities([testtarget, Base, Core]; askwargs(ambiguities)...)
-            end
+            test_ambiguities([testtarget, Base, Core]; askwargs(ambiguities)...)
         end
     end
     @testset "Unbound type parameters" begin

--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -108,7 +108,7 @@ is_foreign(@nospecialize(T::TypeVar), pkg::Base.PkgId; treat_as_own) =
     is_foreign(T.ub, pkg; treat_as_own = treat_as_own)
 
 # Before 1.7, Vararg was a UnionAll, so the UnionAll method will work
-@static if VERSION >= v"1.7"
+@static if VERSION >= v"1.7-"
     is_foreign(@nospecialize(T::Core.TypeofVararg), pkg::Base.PkgId; treat_as_own) =
         is_foreign(T.T, pkg; treat_as_own = treat_as_own)
 end


### PR DESCRIPTION
This branch contains some special code for versions between https://github.com/JuliaLang/julia/pull/36962 (`v1.6.0-DEV.816`) and https://github.com/JuliaLang/julia/pull/37484 (`v1.6.0-DEV.875`).

I think Aqua should not need to support DEV builds that are more than 2 years old.
Thus I propose to remove the branch.