### PR TITLE
Remove hidden doc page

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, Aqua
 
 makedocs(;
     modules = [Aqua],
-    pages = ["Home" => "index.md", hide("internals.md")],
+    pages = ["Home" => "index.md"],
     sitename = "Aqua.jl",
     authors = "Takafumi Arakaki",
 )

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,7 +1,0 @@
-# Internals
-
-```@autodocs
-Modules = [Aqua]
-Public = false
-Filter = t -> !startswith(String(nameof(t)), "test_")
-```


### PR DESCRIPTION
Accessible via https://juliatesting.github.io/Aqua.jl/dev/internals/

It contains no sensible content, so I don't know why we should keep it.

