### PR TITLE
Move `test_pirate` out of the `Aqua.Piracy` module

### DIFF
--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -28,8 +28,6 @@ include("deps_compat.jl")
 include("project_toml_formatting.jl")
 include("piracy.jl")
 
-using .Piracy: test_piracy
-
 """
     test_all(testtarget::Module)
 

--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -161,6 +161,8 @@ function hunt(pkg::Base.PkgId; from::Module)
     end
 end
 
+end # module
+
 """
     test_piracy(m::Module)
 
@@ -172,7 +174,7 @@ See [Julia documentation](https://docs.julialang.org/en/v1/manual/style-guide/#A
   `@test`.
 """
 function test_piracy(m::Module; broken::Bool = false)
-    v = hunt(m)
+    v = Piracy.hunt(m)
     if !isempty(v)
         printstyled(
             stderr,
@@ -189,5 +191,3 @@ function test_piracy(m::Module; broken::Bool = false)
         @test isempty(v)
     end
 end
-
-end # module


### PR DESCRIPTION
This implicitly fixes some wrong references in docstrings (`test_piracy` instead of `Piracy.test_piracy`) and sorts `test_piracy` alphabetically between the other docstrings.

Furthermore works around https://github.com/JuliaLang/julia/issues/36529 by making it obsolete, i.e. tab-completing `Aqua.test_piracy` in the REPL works now.