### PR TITLE
Fix `treat_as_own`

### DIFF
--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -167,7 +167,7 @@ hunt(mod::Module; from::Module = mod, kwargs...) =
 
 function hunt(pkg::Base.PkgId; from::Module, kwargs...)
     filter(all_methods(from)) do method
-        Base.PkgId(method.module) === pkg && is_pirate(method, kwargs...)
+        Base.PkgId(method.module) === pkg && is_pirate(method; kwargs...)
     end
 end
 


### PR DESCRIPTION
Due to a dumb typo on my side (which I definitely should have noticed), the `test_piracy` kwarg `treat_as_own` is broken in the `0.6.4` release. This fixes it. I propose the following line of action:

- [ ] Yank `0.6.4` or just ignore it as we have a newer release anyway (see point 3).
- [ ] Merge https://github.com/JuliaTesting/Aqua.jl/pull/152 to revert the breaking change.
- [ ] Merge this PR.
- [ ] Make a new release.
- [ ] Revert https://github.com/JuliaTesting/Aqua.jl/pull/152 to again include the breaking change.

Is this fine for you @fingolfin ?