### PR TITLE
Enhance Piracy detection by considering more methods

### DIFF
--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -1,6 +1,18 @@
 module Piracy
 
-import Test
+if VERSION >= v"1.6-"
+    using Test: is_in_mods
+else
+    function is_in_mods(m::Module, recursive::Bool, mods)
+        while true
+            m in mods && return true
+            recursive || return false
+            p = parentmodule(m)
+            p === m && return false
+            m = p
+        end
+    end
+end
 
 # based on Test/Test.jl#detect_ambiguities
 # https://github.com/JuliaLang/julia/blob/v1.9.1/stdlib/Test/src/Test.jl#L1838-L1896
@@ -13,7 +25,7 @@ function all_methods(mods::Module...; skip_deprecated::Bool)
     end
     function examine(ml::Base.MethodList)
         for m in ml
-            Test.is_in_mods(m.module, true, mods) || continue
+            is_in_mods(m.module, true, mods) || continue
             push!(meths, m)
         end
     end

--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -16,7 +16,7 @@ end
 
 # based on Test/Test.jl#detect_ambiguities
 # https://github.com/JuliaLang/julia/blob/v1.9.1/stdlib/Test/src/Test.jl#L1838-L1896
-function all_methods(mods::Module...; skip_deprecated::Bool)
+function all_methods(mods::Module...; skip_deprecated::Bool = true)
     meths = Method[]
     mods = collect(mods)::Vector{Module}
 
@@ -173,12 +173,9 @@ function is_pirate(meth::Method; treat_as_own = Union{Function,Type}[])
     )
 end
 
-hunt(mod::Module; from::Module = mod, kwargs...) =
-    hunt(Base.PkgId(mod); from = from, kwargs...)
-
-function hunt(pkg::Base.PkgId; from::Module, skip_deprecated::Bool = true, kwargs...)
-    filter(all_methods(from; skip_deprecated = skip_deprecated)) do method
-        Base.PkgId(method.module) === pkg && is_pirate(method; kwargs...)
+function hunt(mod::Module; skip_deprecated::Bool = true, kwargs...)
+    filter(all_methods(mod; skip_deprecated = skip_deprecated)) do method
+        method.module === mod && is_pirate(method; kwargs...)
     end
 end
 

--- a/test/pkgs/PiracyForeignProject/src/PiracyForeignProject.jl
+++ b/test/pkgs/PiracyForeignProject/src/PiracyForeignProject.jl
@@ -3,4 +3,8 @@ module PiracyForeignProject
 struct ForeignType end
 struct ForeignParameterizedType{T} end
 
+struct ForeignNonSingletonType
+    x::Int
+end
+
 end

--- a/test/test_piracy.jl
+++ b/test/test_piracy.jl
@@ -63,7 +63,7 @@ using Aqua: Piracy
 using PiracyForeignProject: ForeignType, ForeignParameterizedType, ForeignNonSingletonType
 
 # Get all methods - test length
-meths = filter(Piracy.all_methods(PiracyModule; skip_deprecated = true)) do m
+meths = filter(Piracy.all_methods(PiracyModule)) do m
     m.module == PiracyModule
 end
 
@@ -90,7 +90,7 @@ ThisPkg = Base.PkgId(PiracyModule)
 @test !Piracy.is_foreign(Set{Int}, CorePkg; treat_as_own = [])
 
 # Test what is pirate
-pirates = filter(m -> Piracy.is_pirate(m), meths)
+pirates = Piracy.hunt(PiracyModule)
 @test length(pirates) ==
       3 + # findfirst
       3 + # findmax
@@ -102,7 +102,7 @@ pirates = filter(m -> Piracy.is_pirate(m), meths)
 end
 
 # Test what is pirate (with treat_as_own=[ForeignType])
-pirates = filter(m -> Piracy.is_pirate(m; treat_as_own = [ForeignType]), meths)
+pirates = Piracy.hunt(PiracyModule, treat_as_own = [ForeignType])
 @test length(pirates) ==
       3 + # findfirst
       3 + # findmin
@@ -112,7 +112,7 @@ pirates = filter(m -> Piracy.is_pirate(m; treat_as_own = [ForeignType]), meths)
 end
 
 # Test what is pirate (with treat_as_own=[ForeignParameterizedType])
-pirates = filter(m -> Piracy.is_pirate(m; treat_as_own = [ForeignParameterizedType]), meths)
+pirates = Piracy.hunt(PiracyModule, treat_as_own = [ForeignParameterizedType])
 @test length(pirates) ==
       3 + # findfirst
       3 + # findmax
@@ -135,8 +135,7 @@ pirates = filter(
 end
 
 # Test what is pirate (with treat_as_own=[Base.findfirst, Base.findmax])
-pirates =
-    filter(m -> Piracy.is_pirate(m; treat_as_own = [Base.findfirst, Base.findmax]), meths)
+pirates = Piracy.hunt(PiracyModule, treat_as_own = [Base.findfirst, Base.findmax])
 @test length(pirates) ==
       3 + # findmin
       1 + # ForeignType callable


### PR DESCRIPTION
Resolves https://github.com/JuliaTesting/Aqua.jl/issues/155 and resolves https://github.com/JuliaTesting/Aqua.jl/issues/157.

The main change is a re-implementation of `all_methods`. Unfortunately, the old data source `names(MyModule)` was missing some callables (https://github.com/JuliaTesting/Aqua.jl/issues/157) and methods of non-imported functions that have been defined in a fully qualified way (https://github.com/JuliaTesting/Aqua.jl/issues/155). The proposed implementation works very similarly to `Test.detect_ambiguities` and `Test.detect_unbound_args` by iterating over all `names` of all currently loaded modules, and then filtering out the methods that are indeed defined in `MyModule`.

I furthermore added some tests displaying the new functionality. The main point here is that https://github.com/JuliaTesting/Aqua.jl/blob/94a9c7a69ee41878774ce2dc4cac05fb4f71c4ed/test/test_piracy.jl#L58-L62
is no longer needed.