### PR TITLE
Circumvent pipe buffer deadlock

### DIFF
--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -126,7 +126,7 @@ function _find_ambiguities(
     end
     cmd = `$cmd --startup-file=no -e $code`
 
-    outfile, out = mktemp(; cleanup = false)
+    outfile, out = mktemp()
     errfile, err = mktemp(; cleanup = false)
     succ = success(pipeline(cmd; stdout = out, stderr = err))
     strout = read(outfile, String)

--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -126,13 +126,11 @@ function _find_ambiguities(
     end
     cmd = `$cmd --startup-file=no -e $code`
 
-    out = Pipe()
-    err = Pipe()
+    outfile, out = mktemp(; cleanup = false)
+    errfile, err = mktemp(; cleanup = false)
     succ = success(pipeline(cmd; stdout = out, stderr = err))
-    close(out.in)
-    close(err.in)
-    strout = String(read(out))
-    strerr = String(read(err))
+    strout = read(outfile, String)
+    strerr = read(errfile, String)
     num_ambiguities = if succ
         0
     else

--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -127,7 +127,7 @@ function _find_ambiguities(
     cmd = `$cmd --startup-file=no -e $code`
 
     outfile, out = mktemp()
-    errfile, err = mktemp(; cleanup = false)
+    errfile, err = mktemp()
     succ = success(pipeline(cmd; stdout = out, stderr = err))
     strout = read(outfile, String)
     strerr = read(errfile, String)


### PR DESCRIPTION
Resolves https://github.com/JuliaTesting/Aqua.jl/issues/165.

@fingolfin please check that on your machine as well.

This should be backported to 0.6.6 and released, as it should occur for every package with many (>150 ambiguities).