### PR TITLE
Protect access to `.instance`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Aqua"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
-version = "0.6.6"
+version = "0.6.7"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/piracy.jl
+++ b/src/piracy.jl
@@ -141,7 +141,7 @@ function is_foreign_method(@nospecialize(T::DataType), pkg::Base.PkgId; treat_as
 
     # fallback to general code
     return !(T in treat_as_own) &&
-           !(T <: Function && T.instance in treat_as_own) &&
+           !(T <: Function && isdefined(T, :instance) && T.instance in treat_as_own) &&
            is_foreign(T, pkg; treat_as_own = treat_as_own)
 end
 


### PR DESCRIPTION
Fixes https://github.com/JuliaTesting/Aqua.jl/issues/167.

This is only an issue on the `release-0.6` branch, as this change has been included in #156.

@fingolfin Could you tag this as 0.6.7?