### PR TITLE
CI: use concrete action version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v1
         with:
           version: 1
       - uses: julia-actions/cache@v1


### PR DESCRIPTION
This is recommended by the [readme](https://github.com/julia-actions/setup-julia#inputs).