### PR TITLE
Add persistent_tasks test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Two additions check whether packages might block precompilation on Julia 1.10 or higher:
-  + `test_persistent_tasks` tests whether "your" package can safely be used as a dependency for downstream packages
-  + `test_persistent_tasks_deps` is useful if "your" package hangs upon precompilation: it runs `test_persistent_tasks` on all the things you depend on, and may help isolate the culprit(s).
-  
+  + `test_persistent_tasks` tests whether "your" package can safely be used as a dependency for downstream packages. This test is disabled for the default testsuite, but you can opt-in by supplying `persistent_tasks=true` to `test_all`.
+  + `find_persistent_tasks_deps` is useful if "your" package hangs upon precompilation: it runs `test_persistent_tasks` on all the things you depend on, and may help isolate the culprit(s).
+
 ### Changed
 
 - The minimum requirement for julia was raised from `1.0` to `1.4`. ([#221](https://github.com/JuliaTesting/Aqua.jl/pull/221))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Two additions check whether packages might block precompilation on Julia 1.10 or higher:
+  + `test_persistent_tasks` tests whether "your" package can safely be used as a dependency for downstream packages
+  + `test_persistent_tasks_deps` is useful if "your" package hangs upon precompilation: it runs `test_persistent_tasks` on all the things you depend on, and may help isolate the culprit(s).
+  
 ### Changed
 
 - The minimum requirement for julia was raised from `1.0` to `1.4`. ([#221](https://github.com/JuliaTesting/Aqua.jl/pull/221))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Two additions check whether packages might block precompilation on Julia 1.10 or higher:
-  + `test_persistent_tasks` tests whether "your" package can safely be used as a dependency for downstream packages. This test is disabled for the default testsuite, but you can opt-in by supplying `persistent_tasks=true` to `test_all`.
+- Two additions check whether packages might block precompilation on Julia 1.10 or higher: ([#174](https://github.com/JuliaTesting/Aqua.jl/pull/174))
+  + `test_persistent_tasks` tests whether "your" package can safely be used as a dependency for downstream packages. This test is enabled for the default testsuite, but you can opt-out by supplying `persistent_tasks=false` to `test_all`. [BREAKING]
   + `find_persistent_tasks_deps` is useful if "your" package hangs upon precompilation: it runs `test_persistent_tasks` on all the things you depend on, and may help isolate the culprit(s).
 
 ### Changed

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,4 @@
-# Aqua.jl: 
+# Aqua.jl:
 ## *A*uto *QU*ality *A*ssurance for Julia packages
 
 Aqua.jl provides functions to run a few automatable checks for Julia packages:
@@ -13,6 +13,7 @@ Aqua.jl provides functions to run a few automatable checks for Julia packages:
   `compat` entry.
 * `Project.toml` formatting is compatible with Pkg.jl output.
 * There are no "obvious" type piracies.
+* The package does not create any persistent Tasks that might block precompilation of dependencies.
 
 ## Quick usage
 
@@ -55,14 +56,14 @@ recommended to add a version bound for Aqua.jl.
     test = ["Aqua", "Test"]
     ```
 
-If your package supports Julia pre-1.2, you need to use the second approach, 
+If your package supports Julia pre-1.2, you need to use the second approach,
 although you can use both approaches at the same time.
 
 !!! warning
     In normal use, `Aqua.jl` should not be added to `[deps]` in `YourPackage/Project.toml`!
 
 ### ...to your tests?
-It is recommended to create a separate file `YourPackage/test/Aqua.jl` that gets included in `YourPackage/test/runtests.jl` 
+It is recommended to create a separate file `YourPackage/test/Aqua.jl` that gets included in `YourPackage/test/runtests.jl`
 with either
 
 ```julia

--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -1,7 +1,7 @@
 module Aqua
 
 using Base: PkgId, UUID
-using Pkg: Pkg, TOML
+using Pkg: Pkg, TOML, PackageSpec
 using Test
 
 @static if VERSION >= v"1.7-"
@@ -21,6 +21,7 @@ include("stale_deps.jl")
 include("deps_compat.jl")
 include("project_toml_formatting.jl")
 include("piracy.jl")
+include("persistent_tasks.jl")
 
 """
     test_all(testtarget::Module)
@@ -35,6 +36,7 @@ Run following tests in isolated testset:
 * [`test_deps_compat(testtarget)`](@ref test_deps_compat)
 * [`test_project_toml_formatting(testtarget)`](@ref test_project_toml_formatting)
 * [`test_piracy(testtarget)`](@ref test_piracy)
+* [`test_persistent_tasks(testtarget)`](@ref test_persistent_tasks)
 
 The keyword argument `\$x` (e.g., `ambiguities`) can be used to
 control whether or not to run `test_\$x` (e.g., `test_ambiguities`).
@@ -50,6 +52,7 @@ passed to `\$x` to specify the keyword arguments for `test_\$x`.
 - `deps_compat = true`
 - `project_toml_formatting = true`
 - `piracy = true`
+- `persistent_tasks = true`
 """
 function test_all(
     testtarget::Module;
@@ -61,6 +64,7 @@ function test_all(
     deps_compat = true,
     project_toml_formatting = true,
     piracy = true,
+    persistent_tasks = true,
 )
     @testset "Method ambiguity" begin
         if ambiguities !== false
@@ -100,6 +104,11 @@ function test_all(
     @testset "Piracy" begin
         if piracy !== false
             test_piracy(testtarget; askwargs(piracy)...)
+        end
+    end
+    @testset "Persistent tasks" begin
+        if persistent_tasks !== false
+            test_persistent_tasks(testtarget; askwargs(persistent_tasks)...)
         end
     end
 end

--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -52,7 +52,7 @@ passed to `\$x` to specify the keyword arguments for `test_\$x`.
 - `deps_compat = true`
 - `project_toml_formatting = true`
 - `piracy = true`
-- `persistent_tasks = false` (will become `true` in the next breaking release)
+- `persistent_tasks = true`
 """
 function test_all(
     testtarget::Module;
@@ -64,7 +64,7 @@ function test_all(
     deps_compat = true,
     project_toml_formatting = true,
     piracy = true,
-    persistent_tasks = false,
+    persistent_tasks = true,
 )
     @testset "Method ambiguity" begin
         if ambiguities !== false

--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -52,7 +52,7 @@ passed to `\$x` to specify the keyword arguments for `test_\$x`.
 - `deps_compat = true`
 - `project_toml_formatting = true`
 - `piracy = true`
-- `persistent_tasks = true`
+- `persistent_tasks = false` (will become `true` in the next breaking release)
 """
 function test_all(
     testtarget::Module;
@@ -64,7 +64,7 @@ function test_all(
     deps_compat = true,
     project_toml_formatting = true,
     piracy = true,
-    persistent_tasks = true,
+    persistent_tasks = false,
 )
     @testset "Method ambiguity" begin
         if ambiguities !== false

--- a/src/persistent_tasks.jl
+++ b/src/persistent_tasks.jl
@@ -116,9 +116,14 @@ end
 
 function precompile_wrapper(project, tmax)
     prev_project = Base.active_project()
+    isdefined(Pkg, :respect_sysimage_versions) && Pkg.respect_sysimage_versions(false)
     try
         pkgdir = dirname(project)
-        pkgname = basename(pkgdir)
+        pkgname = get(TOML.parsefile(project), "name", nothing)
+        if isnothing(pkgname)
+            @error "Unable to locate package name in $project"
+            return false
+        end
         wrapperdir = tempname()
         wrappername, _ = only(Pkg.generate(wrapperdir))
         Pkg.activate(wrapperdir)
@@ -160,6 +165,7 @@ end
         end
         return success
     finally
+        isdefined(Pkg, :respect_sysimage_versions) && Pkg.respect_sysimage_versions(true)
         Pkg.activate(prev_project)
     end
 end

--- a/src/persistent_tasks.jl
+++ b/src/persistent_tasks.jl
@@ -1,0 +1,145 @@
+"""
+    Aqua.test_persistent_tasks(package; tmax=5)
+
+Test whether loading `package` creates persistent `Task`s
+which may block precompilation of dependent packages.
+
+# Motivation
+
+Julia 1.10 and higher wait for all running `Task`s to finish
+before writing out the precompiled (cached) version of the package.
+One consequence is that a package that launches
+`Task`s in its `__init__` function may precompile successfully,
+but block precompilation of any packages that depend on it.
+
+# Example
+
+Let's create a dummy package, `PkgA`, that launches a persistent `Task`:
+
+```julia
+
+```julia
+module PkgA
+const t = Ref{Any}()   # to prevent the Timer from being garbage-collected
+__init__() = t[] = Timer(0.1; interval=1)   # create a persistent `Timer` `Task`
+end
+```
+
+`PkgA` will precompile successfully, because `PkgA.__init__()` does not
+run when `PkgA` is precompiled. However,
+
+```julia
+module PkgB
+using PkgA
+end
+```
+
+fails to precompile: `using PkgA` runs `PkgA.__init__()`, which
+leaves the `Timer` `Task` running, and that causes precompilation
+of `PkgB` to hang.
+
+# How the test works
+
+This test works by launching a Julia process that tries to precompile a
+dummy package similar to `PkgB` above, modified to signal back to Aqua when
+`PkgA` has finished loading. The test fails if the gap between loading `PkgA`
+and finishing precompilation exceeds time `tmax`.
+
+# How to fix failing packages
+
+Often, the easiest fix is to modify the `__init__` function to check whether the
+Julia process is precompiling some other package; if so, don't launch the
+persistent `Task`s.
+
+```
+function __init__()
+    # Other setup code here
+    if ccall(:jl_generating_output, Cint, ()) == 0   # if we're not precompiling...
+        # launch persistent tasks here
+    end
+end
+```
+
+In more complex cases, you may need to set up independently-callable functions
+to launch the tasks and cleanly shut them down.
+
+# Arguments
+- `package`: a top-level `Module` or `Base.PkgId`.
+
+# Keyword Arguments
+- `tmax::Real`: the maximum time (in seconds) to wait between loading the
+  package and forced shutdown of the precompilation process.
+"""
+function test_persistent_tasks(package::PkgId; tmax=5, fails::Bool=false)
+    @testset "$package persistent_tasks" begin
+        result = root_project_or_failed_lazytest(package)
+        result isa LazyTestResult && return result
+        @test fails ⊻ precompile_wrapper(result, tmax)
+    end
+end
+
+function test_persistent_tasks(package::Module; kwargs...)
+    test_persistent_tasks(PkgId(package); kwargs...)
+end
+
+"""
+    Aqua.test_persistent_tasks_deps(package; kwargs...)
+
+Test all the dependencies of `package` with [`Aqua.test_persistent_tasks`](@ref).
+"""
+function test_persistent_tasks_deps(package::PkgId; fails=Dict{String,Bool}(), kwargs...)
+    result = root_project_or_failed_lazytest(package)
+    result isa LazyTestResult && return result
+    prj = TOML.parsefile(result)
+    deps = get(prj, "deps", nothing)
+    @testset "$result" begin
+        if deps === nothing
+            return LazyTestResult("$package", "`$result` does not have `deps`", true)
+        else
+            for (name, uuid) in deps
+                id = PkgId(UUID(uuid), name)
+                test_persistent_tasks(id; fails=get(fails, name, false), kwargs...)
+            end
+        end
+    end
+end
+
+function test_persistent_tasks_deps(package::Module; kwargs...)
+    test_persistent_tasks_deps(PkgId(package); kwargs...)
+end
+
+function precompile_wrapper(project, tmax)
+    pkgdir = dirname(project)
+    pkgname = basename(pkgdir)
+    wrapperdir = tempname()
+    wrappername, wrapperuuid = only(Pkg.generate(wrapperdir))
+    Pkg.activate(wrapperdir)
+    Pkg.develop(PackageSpec(path=pkgdir))
+    open(joinpath(wrapperdir, "src", wrappername * ".jl"), "w") do io
+        println(io, """
+        module $wrappername
+        using $pkgname
+        # Signal Aqua from the precompilation process that we've finished loading the package
+        open(joinpath("$wrapperdir", "done.log"), "w") do io
+            println(io, "done")
+        end
+        end
+        """)
+    end
+    # Precompile the wrapper package
+    cmd = `$(Base.julia_cmd()) --project=$wrapperdir -e 'using Pkg; Pkg.precompile()'`
+    proc = run(cmd; wait=false)
+    while !isfile(joinpath(wrapperdir, "done.log"))
+        sleep(0.1)
+    end
+    # Check whether precompilation finishes in the required time
+    t = time()
+    while process_running(proc) && time() - t < tmax
+        sleep(0.1)
+    end
+    success = !process_running(proc)
+    if !success
+        kill(proc)
+    end
+    return success
+end

--- a/src/persistent_tasks.jl
+++ b/src/persistent_tasks.jl
@@ -68,12 +68,18 @@ to launch the tasks and cleanly shut them down.
 - `tmax::Real`: the maximum time (in seconds) to wait after loading the
   package before forcibly shutting down the precompilation process (triggering
   a test failure).
+- `broken::Bool = false`: If true, it uses `@test_broken` instead of
+  `@test`.
 """
-function test_persistent_tasks(package::PkgId; tmax = 10, fails::Bool = false)
+function test_persistent_tasks(package::PkgId; tmax = 10, broken::Bool = false)
     @testset "$package persistent_tasks" begin
         result = root_project_or_failed_lazytest(package)
         result isa LazyTestResult && return result
-        @test fails ⊻ precompile_wrapper(result, tmax)
+        if broken
+            @test_broken precompile_wrapper(result, tmax)
+        else
+            @test precompile_wrapper(result, tmax)
+        end
     end
 end
 

--- a/src/persistent_tasks.jl
+++ b/src/persistent_tasks.jl
@@ -125,7 +125,7 @@ function precompile_wrapper(project, tmax)
 module $wrappername
 using $pkgname
 # Signal Aqua from the precompilation process that we've finished loading the package
-open("$statusfile", "w") do io
+open("$(escape_string(statusfile))", "w") do io
     println(io, "done")
     flush(io)
 end

--- a/src/persistent_tasks.jl
+++ b/src/persistent_tasks.jl
@@ -93,7 +93,7 @@ end
     Aqua.find_persistent_tasks_deps(package; broken = Dict{String,Bool}(), kwargs...)
 
 Test all the dependencies of `package` with [`Aqua.test_persistent_tasks`](@ref).
-On Julia 1.10 and higher, you returns a list of all dependencies failing the test.
+On Julia 1.10 and higher, it returns a list of all dependencies failing the test.
 These are likely the ones blocking precompilation of your package.
 
 Any additional kwargs (e.g., `tmax`) are passed to [`Aqua.test_persistent_tasks`](@ref).

--- a/test/pkgs/PersistentTasks/PersistentTask/Project.toml
+++ b/test/pkgs/PersistentTasks/PersistentTask/Project.toml
@@ -1,0 +1,4 @@
+name = "PersistentTask"
+uuid = "e5c298b6-d81d-47aa-a9ed-5ea983e22986"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+version = "0.1.0"

--- a/test/pkgs/PersistentTasks/PersistentTask/Project.toml
+++ b/test/pkgs/PersistentTasks/PersistentTask/Project.toml
@@ -1,4 +1,2 @@
 name = "PersistentTask"
 uuid = "e5c298b6-d81d-47aa-a9ed-5ea983e22986"
-authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.1.0"

--- a/test/pkgs/PersistentTasks/PersistentTask/src/PersistentTask.jl
+++ b/test/pkgs/PersistentTasks/PersistentTask/src/PersistentTask.jl
@@ -1,6 +1,6 @@
 module PersistentTask
 
 const t = Ref{Any}()
-__init__() = t[] = Timer(0.1; interval=1)   # create a persistent `Timer` `Task`
+__init__() = t[] = Timer(0.1; interval = 1)   # create a persistent `Timer` `Task`
 
 end # module PersistentTask

--- a/test/pkgs/PersistentTasks/PersistentTask/src/PersistentTask.jl
+++ b/test/pkgs/PersistentTasks/PersistentTask/src/PersistentTask.jl
@@ -1,0 +1,6 @@
+module PersistentTask
+
+const t = Ref{Any}()
+__init__() = t[] = Timer(0.1; interval=1)   # create a persistent `Timer` `Task`
+
+end # module PersistentTask

--- a/test/pkgs/PersistentTasks/TransientTask/Project.toml
+++ b/test/pkgs/PersistentTasks/TransientTask/Project.toml
@@ -1,4 +1,2 @@
 name = "TransientTask"
 uuid = "94ae9332-58b0-4342-989c-0a7e44abcca9"
-authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.1.0"

--- a/test/pkgs/PersistentTasks/TransientTask/Project.toml
+++ b/test/pkgs/PersistentTasks/TransientTask/Project.toml
@@ -1,0 +1,4 @@
+name = "TransientTask"
+uuid = "94ae9332-58b0-4342-989c-0a7e44abcca9"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+version = "0.1.0"

--- a/test/pkgs/PersistentTasks/TransientTask/src/TransientTask.jl
+++ b/test/pkgs/PersistentTasks/TransientTask/src/TransientTask.jl
@@ -1,0 +1,5 @@
+module TransientTask
+
+__init__() = Timer(0.1)   # create a transient `Timer` `Task`
+
+end # module TransientTask

--- a/test/pkgs/PersistentTasks/UsesBoth/Project.toml
+++ b/test/pkgs/PersistentTasks/UsesBoth/Project.toml
@@ -1,7 +1,5 @@
 name = "UsesBoth"
 uuid = "96f12b6e-60f8-43dc-b131-049a88a2f499"
-authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.1.0"
 
 [deps]
 PersistentTask = "e5c298b6-d81d-47aa-a9ed-5ea983e22986"

--- a/test/pkgs/PersistentTasks/UsesBoth/Project.toml
+++ b/test/pkgs/PersistentTasks/UsesBoth/Project.toml
@@ -1,0 +1,8 @@
+name = "UsesBoth"
+uuid = "96f12b6e-60f8-43dc-b131-049a88a2f499"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+PersistentTask = "e5c298b6-d81d-47aa-a9ed-5ea983e22986"
+TransientTask = "94ae9332-58b0-4342-989c-0a7e44abcca9"

--- a/test/pkgs/PersistentTasks/UsesBoth/src/UsesBoth.jl
+++ b/test/pkgs/PersistentTasks/UsesBoth/src/UsesBoth.jl
@@ -1,0 +1,6 @@
+module UsesBoth
+
+using TransientTask
+using PersistentTask
+
+end # module UsesBoth

--- a/test/test_persistent_tasks.jl
+++ b/test/test_persistent_tasks.jl
@@ -19,8 +19,11 @@ end
     Aqua.test_persistent_tasks_deps(getid("TransientTask"))
 
     if Base.VERSION >= v"1.10-"
-        Aqua.test_persistent_tasks(getid("PersistentTask"); fails=true)
-        Aqua.test_persistent_tasks_deps(getid("UsesBoth"); fails=Dict("PersistentTask" => true))
+        Aqua.test_persistent_tasks(getid("PersistentTask"); fails = true)
+        Aqua.test_persistent_tasks_deps(
+            getid("UsesBoth");
+            fails = Dict("PersistentTask" => true),
+        )
     end
     filter!(str -> !occursin("PersistentTasks", str), LOAD_PATH)
 end

--- a/test/test_persistent_tasks.jl
+++ b/test/test_persistent_tasks.jl
@@ -15,15 +15,16 @@ end
 
 
 @testset "PersistentTasks" begin
-    Aqua.test_persistent_tasks(getid("TransientTask"))
-    Aqua.test_persistent_tasks_deps(getid("TransientTask"))
+    @test !Aqua.has_persistent_tasks(getid("TransientTask"))
+
+    result = Aqua.find_persistent_tasks_deps(getid("TransientTask"))
+    @test result == []
 
     if Base.VERSION >= v"1.10-"
-        Aqua.test_persistent_tasks(getid("PersistentTask"); broken = true)
-        Aqua.test_persistent_tasks_deps(
-            getid("UsesBoth");
-            broken = Dict("PersistentTask" => true),
-        )
+        @test Aqua.has_persistent_tasks(getid("PersistentTask"))
+
+        result = Aqua.find_persistent_tasks_deps(getid("UsesBoth"))
+        @test result == ["PersistentTask"]
     end
     filter!(str -> !occursin("PersistentTasks", str), LOAD_PATH)
 end

--- a/test/test_persistent_tasks.jl
+++ b/test/test_persistent_tasks.jl
@@ -1,0 +1,28 @@
+module TestPersistentTasks
+
+include("preamble.jl")
+using Base: PkgId, UUID
+using Pkg: TOML
+
+function getid(name)
+    path = joinpath(@__DIR__, "pkgs", "PersistentTasks", name)
+    if path ∉ LOAD_PATH
+        pushfirst!(LOAD_PATH, path)
+    end
+    prj = TOML.parsefile(joinpath(path, "Project.toml"))
+    return PkgId(UUID(prj["uuid"]), prj["name"])
+end
+
+
+@testset "PersistentTasks" begin
+    Aqua.test_persistent_tasks(getid("TransientTask"))
+    Aqua.test_persistent_tasks_deps(getid("TransientTask"))
+
+    if all((Base.VERSION.major, Base.VERSION.minor) .>= (1, 10))
+        Aqua.test_persistent_tasks(getid("PersistentTask"); fails=true)
+        Aqua.test_persistent_tasks_deps(getid("UsesBoth"); fails=Dict("PersistentTask" => true))
+    end
+    filter!(str -> !occursin("PersistentTasks", str), LOAD_PATH)
+end
+
+end

--- a/test/test_persistent_tasks.jl
+++ b/test/test_persistent_tasks.jl
@@ -19,10 +19,10 @@ end
     Aqua.test_persistent_tasks_deps(getid("TransientTask"))
 
     if Base.VERSION >= v"1.10-"
-        Aqua.test_persistent_tasks(getid("PersistentTask"); fails = true)
+        Aqua.test_persistent_tasks(getid("PersistentTask"); broken = true)
         Aqua.test_persistent_tasks_deps(
             getid("UsesBoth");
-            fails = Dict("PersistentTask" => true),
+            broken = Dict("PersistentTask" => true),
         )
     end
     filter!(str -> !occursin("PersistentTasks", str), LOAD_PATH)

--- a/test/test_persistent_tasks.jl
+++ b/test/test_persistent_tasks.jl
@@ -18,7 +18,7 @@ end
     Aqua.test_persistent_tasks(getid("TransientTask"))
     Aqua.test_persistent_tasks_deps(getid("TransientTask"))
 
-    if all((Base.VERSION.major, Base.VERSION.minor) .>= (1, 10))
+    if Base.VERSION >= v"1.10-"
         Aqua.test_persistent_tasks(getid("PersistentTask"); fails=true)
         Aqua.test_persistent_tasks_deps(getid("UsesBoth"); fails=Dict("PersistentTask" => true))
     end

--- a/test/test_smoke.jl
+++ b/test/test_smoke.jl
@@ -16,7 +16,7 @@ Aqua.test_all(
     deps_compat = (; check_extras = true, check_weakdeps = true),
     project_toml_formatting = false,
     piracy = false,
-    persistent_tasks = true,
+    persistent_tasks = false,
 )
 
 end  # module

--- a/test/test_smoke.jl
+++ b/test/test_smoke.jl
@@ -16,6 +16,7 @@ Aqua.test_all(
     deps_compat = (; check_extras = true, check_weakdeps = true),
     project_toml_formatting = false,
     piracy = false,
+    persistent_tasks = true,
 )
 
 end  # module


### PR DESCRIPTION
This checks whether a package spawns persistent `Task`s that might block precompilation of dependents of the package. It also provides a convenience utility, `test_persistent_tasks_deps`, for checking all the dependencies of a given package, to simplify discovery. If one runs one of the tests in this PR without annotating one as an expected failure, here is the output on Julia 1.10-beta:

```julia
julia> Aqua.test_persistent_tasks_deps(getid("UsesBoth"))
  Generating  project jl_jqh8hMTOr6:
    /tmp/jl_jqh8hMTOr6/Project.toml
    /tmp/jl_jqh8hMTOr6/src/jl_jqh8hMTOr6.jl
  Activating project at `/tmp/jl_jqh8hMTOr6`
   Resolving package versions...
    Updating `/tmp/jl_jqh8hMTOr6/Project.toml`
  [94ae9332] + TransientTask v0.1.0 `~/.julia/dev/Aqua/test/pkgs/PersistentTasks/TransientTask`
    Updating `/tmp/jl_jqh8hMTOr6/Manifest.toml`
  [94ae9332] + TransientTask v0.1.0 `~/.julia/dev/Aqua/test/pkgs/PersistentTasks/TransientTask`
  Generating  project jl_FI7OrSlgVA:
    /tmp/jl_FI7OrSlgVA/Project.toml
    /tmp/jl_FI7OrSlgVA/src/jl_FI7OrSlgVA.jl
  Activating project at `/tmp/jl_FI7OrSlgVA`
   Resolving package versions...
    Updating `/tmp/jl_FI7OrSlgVA/Project.toml`
  [e5c298b6] + PersistentTask v0.1.0 `~/.julia/dev/Aqua/test/pkgs/PersistentTasks/PersistentTask`
    Updating `/tmp/jl_FI7OrSlgVA/Manifest.toml`
  [e5c298b6] + PersistentTask v0.1.0 `~/.julia/dev/Aqua/test/pkgs/PersistentTasks/PersistentTask`
PersistentTask [e5c298b6-d81d-47aa-a9ed-5ea983e22986] persistent_tasks: Test Failed at /home/tim/.julia/dev/Aqua/src/persistent_tasks.jl:77
  Expression: fails ⊻ precompile_wrapper(result, tmax)

Stacktrace:
 [1] macro expansion
   @ Aqua ~/.julia/juliaup/julia-1.10.0-beta2+0.x64.linux.gnu/share/julia/stdlib/v1.10/Test/src/Test.jl:672 [inlined]
 [2] macro expansion
   @ Aqua ~/.julia/dev/Aqua/src/persistent_tasks.jl:77 [inlined]
 [3] macro expansion
   @ Aqua ~/.julia/juliaup/julia-1.10.0-beta2+0.x64.linux.gnu/share/julia/stdlib/v1.10/Test/src/Test.jl:1577 [inlined]
 [4] test_persistent_tasks(package::PkgId; tmax::Int64, fails::Bool)
   @ Aqua ~/.julia/dev/Aqua/src/persistent_tasks.jl:75
Test Summary:                                                             | Pass  Fail  Total   Time
/home/tim/.julia/dev/Aqua/test/pkgs/PersistentTasks/UsesBoth/Project.toml |    1     1      2  10.2s
  TransientTask [94ae9332-58b0-4342-989c-0a7e44abcca9] persistent_tasks   |    1            1   2.5s
  PersistentTask [e5c298b6-d81d-47aa-a9ed-5ea983e22986] persistent_tasks  |          1      1   7.7s
ERROR: Some tests did not pass: 1 passed, 1 failed, 0 errored, 0 broken.
```

Closes https://github.com/JuliaLang/julia/pull/50914

CC @vtjnash
