### PR TITLE
CI: set a timeout of 10 minutes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   Documenter:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       matrix:
         os: ["ubuntu-latest"]


### PR DESCRIPTION
Otherwise hanging tests block a CI runner for up to 6 hours
