### PR TITLE
Add compat for `Documenter.jl`

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "0.27.0"


### PR DESCRIPTION
I know that there already is a `1.0.1`, but since there are some issues with the docs (cf. #181), I would like to first fix it for the previous Documenter version (and thus fix its version), and then at a later point bump it to 1.0.