### PR TITLE
Streamline uses of Compat.jl

### DIFF
--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -4,10 +4,8 @@ using Base: PkgId, UUID
 using Pkg: Pkg, TOML
 using Test
 
-try
-    findnext('a', "a", 1)
-catch
-    import Compat
+if VERSION < v"1.3.0-DEV.349"
+    using Compat: findfirst
 end
 
 include("pkg/Versions.jl")

--- a/src/pkg/Versions.jl
+++ b/src/pkg/Versions.jl
@@ -4,7 +4,7 @@ module Versions
 
 export VersionBound, VersionRange, VersionSpec, semver_spec, isjoinable
 
-if !@isdefined(isnothing)
+if VERSION < v"1.1.0-DEV.472"
     using Compat: isnothing
 end
 


### PR DESCRIPTION
The version numbers have been found using the approach in https://github.com/JuliaLang/Compat.jl/tree/release-3#developer-tips.