### PR TITLE
Make CI jobs runable by hand

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
       - master
     tags: '*'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   Documenter:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - master
     tags: '*'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
to be able to run the documentation build for all skipped versions (cf. #182)