### PR TITLE
Fix `is_kwcall` for methods with type parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `test_piracy` no longer prints warnings for methods where the third argument is a `TypeVar`. ([#188](https://github.com/JuliaTesting/Aqua.jl/pull/188))
+
 
 ## [0.7.2] - 2023-09-19
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -161,13 +161,12 @@ end
 function is_kwcall(signature::DataType)
     @static if VERSION < v"1.9"
         try
-            return length(signature.parameters) >= 3 &&
-                   signature <: Tuple{Function,Any,Any,Vararg} &&
-                   (
-                       signature.parameters[3] <: Type ||
-                       isconcretetype(signature.parameters[3])
-                   ) &&
-                   signature.parameters[1] === Core.kwftype(signature.parameters[3])
+            length(signature.parameters) >= 3 || return false
+            signature <: Tuple{Function,Any,Any,Vararg} || return false
+            (signature.parameters[3] isa DataType && signature.parameters[3] <: Type) ||
+                isconcretetype(signature.parameters[3]) ||
+                return false
+            return signature.parameters[1] === Core.kwftype(signature.parameters[3])
         catch err
             @warn "Please open an issue on JuliaTesting/Aqua.jl for \"is_kwcall\" and the following data:" signature err
             return false


### PR DESCRIPTION
Fixes https://github.com/JuliaTesting/Aqua.jl/issues/186.

`is_kwcall` currently fails on julia 1.8 and older for methods where the third argument type is not a `DataType` but e.g. a `TypeVar`. This change only calls the erroring function in case that it is indeed a `DataType`.