### PR TITLE
Add Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,110 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+
+## [0.7.2] - 2023-09-19
+
+### Changed
+
+- `test_undefined_exports` additionally prints the modules of the undefined exports in the failure report. ([#177](https://github.com/JuliaTesting/Aqua.jl/pull/177))
+
+
+## [0.7.1] - 2023-09-05
+
+### Fixed
+
+- `test_piracy` no longer reports type piracy in the kwsorter, i.e. `kwcall` should no longer appear in the report. ([#171](https://github.com/JuliaTesting/Aqua.jl/pull/171))
+
+
+## [0.7.0] - 2023-08-29
+
+### Added
+
+- Installation and usage instructions to the documentation. ([#159](https://github.com/JuliaTesting/Aqua.jl/pull/159))
+
+### Changed
+
+- `test_ambiguities` now allows to exclude non-singleton callables. Excluding a type means to exclude all methods of the callable (sometimes also called "functor") and the constructor. ([#144](https://github.com/JuliaTesting/Aqua.jl/pull/144)) [BREAKING]
+- `test_piracy` considers more functions. Callables and qualified names are now also checked. ([#156](https://github.com/JuliaTesting/Aqua.jl/pull/156)) [BREAKING]
+
+### Fixed
+
+- `test_ambiguities` prints less unnecessary whitespace. ([#158](https://github.com/JuliaTesting/Aqua.jl/pull/158))
+- `test_ambiguities` no longer hangs indefinitely when there are many ambiguities. ([#166](https://github.com/JuliaTesting/Aqua.jl/pull/166))
+
+
+## [0.6.7] - 2023-09-19
+
+### Changed
+
+- `test_undefined_exports` additionally prints the modules of the undefined exports in the failure report. ([#177](https://github.com/JuliaTesting/Aqua.jl/pull/177))
+
+### Fixed
+
+- `test_ambiguities` prints less unnecessary whitespace. ([#158](https://github.com/JuliaTesting/Aqua.jl/pull/158))
+- Fix `test_piracy` for some methods with arguments of custom subtypes of `Function`. ([#170](https://github.com/JuliaTesting/Aqua.jl/pull/170))
+
+
+## [0.6.6] - 2023-08-24
+
+### Fixed
+
+- `test_ambiguities` no longer hangs indefinitely when there are many ambiguities. ([#166](https://github.com/JuliaTesting/Aqua.jl/pull/166))
+
+
+## [0.6.5] - 2023-06-26
+
+### Fixed
+
+- Typo when calling kwargs. ([#153](https://github.com/JuliaTesting/Aqua.jl/pull/153))
+
+
+## [0.6.4] - 2023-06-25
+
+### Added
+
+- `test_piracy` has a new kwarg `treat_as_own`. It is useful for testing packages that deliberately commit some type piracy, e.g. modules adding higher-level functionality to a lightweight C-wrapper, or packages that are extending `StatsAPI.jl`. ([#140](https://github.com/JuliaTesting/Aqua.jl/pull/140))
+
+### Changed
+
+- Explanation of `test_unbound_args` in the docstring. ([#146](https://github.com/JuliaTesting/Aqua.jl/pull/146))
+
+### Fixed
+
+- Callable objects with type parameters no longer error in `test_ambiguities`' kwarg `exclude`. ([#142](https://github.com/JuliaTesting/Aqua.jl/pull/142))
+
+
+## [0.6.3] - 2023-06-05
+
+### Changed
+
+- When installing a method for a union type, it is only reported by `test_piracy` if *all* types in the union are foreign (instead of *any* for arguments). ([#131](https://github.com/JuliaTesting/Aqua.jl/pull/131))
+
+### Fixed
+
+- `test_deps_compat`'s kwarg `ignore` now works as intended. ([#130](https://github.com/JuliaTesting/Aqua.jl/pull/130))
+- Weakdeps are not reported as stale by `test_stale_deps` anymore. ([#135](https://github.com/JuliaTesting/Aqua.jl/pull/135))
+
+
+## [0.6.2] - 2023-06-02
+
+### Added
+
+- `test_ambiguities`, `test_undefined_exports`, `test_piracy`, and `test_unbound_args` each have a new kwarg `broken` to mark the test as broken using `Test.@test_broken`. ([#124](https://github.com/JuliaTesting/Aqua.jl/pull/124))
+
+### Changed
+
+- `test_piracy` now prints the offending methods in a more readable way. ([#93](https://github.com/JuliaTesting/Aqua.jl/pull/93))
+- Extend `test_project_toml_formatting` to `docs/Project.toml`. ([#115](https://github.com/JuliaTesting/Aqua.jl/pull/115))
+
+### Fixed
+
+- `test_stale_deps` no longer fails if any of the loaded packages prints during loading. ([#113](https://github.com/JuliaTesting/Aqua.jl/pull/113))
+- Clarified the error message of `test_unbound_args`. ([#103](https://github.com/JuliaTesting/Aqua.jl/pull/103))
+- Clarified the error message of `test_project_toml_formatting`. ([#122](https://github.com/JuliaTesting/Aqua.jl/pull/122))

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Aqua.jl provides functions to run a few automatable checks for Julia packages:
 
 See more in the [documentation](https://juliatesting.github.io/Aqua.jl/).
 
+For a detailed list of changes please refer to the [changelog](CHANGELOG.md).
+
 ## Setup
 
 Please consult the [stable documentation](https://juliatesting.github.io/Aqua.jl/) and the the [dev documentation](https://juliatesting.github.io/Aqua.jl/dev/) for the latest instructions.


### PR DESCRIPTION
The release notes generated by TagBot are mostly cluttered with internal changes (CI, typos, etc.), so that it is hard for a user to find the relevant changes, in particular the breaking changes between breaking releases.

This PR adds a changelog that contains one-liner for all user-facing changes, in particular:

- new tests
- new kwargs to existing tests
- fixes for reported bugs
- breaking changes

This PR fills that in back to v0.6.1 (when I started using and working on Aqua.jl), and I expect all future PRs with relevant changes to add a sentence to the changelog as well.