### PR TITLE
Add more CI targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,17 @@ jobs:
           - 'nightly'
         include:
           - os: windows-latest
-            julia-version: 1
+            julia-version: '1'
           - os: windows-latest
             julia-version: '1.0'
+          - os: windows-latest
+            julia-version: 'nightly'
+          - os: macOS-latest
+            julia-version: '1'
+          - os: macOS-latest
+            julia-version: '1.0'
+          - os: macOS-latest
+            julia-version: 'nightly'
       fail-fast: false
     name: Test Julia ${{ matrix.julia-version }} ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Test on macos as well, as well as against julia nightly on both macos and windows to hopefully catch problems early.