### PR TITLE
Add option to `test_deps_compat` to test extras and weakdeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `test_deps_compat` has two new kwargs `check_extras` and `check_weakdeps` to extend the test to these dependency categories. They are not run by default. ([#200](https://github.com/JuliaTesting/Aqua.jl/pull/200))
+
 ### Changed
 
 - The docstring for `test_stale_deps` explains the situation with package extensions. ([#203](https://github.com/JuliaTesting/Aqua.jl/pull/203))

--- a/test/test_smoke.jl
+++ b/test/test_smoke.jl
@@ -16,7 +16,7 @@ Aqua.test_all(
     undefined_exports = false,
     project_extras = false,
     stale_deps = false,
-    deps_compat = false,
+    deps_compat = (; check_extras = true, check_weakdeps = true),
     project_toml_formatting = false,
     piracy = false,
 )


### PR DESCRIPTION
Resolves https://github.com/JuliaTesting/Aqua.jl/issues/178 and adds the same for `weakdeps` as well.

The tests are disabled by default, until maybe the next breaking release (see https://github.com/JuliaTesting/Aqua.jl/pull/202).