### PR TITLE
Change defaults for `check_extras` and `check_weakdeps`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The minimum requirement for julia was raised from `1.0` to `1.4`. ([#221](https://github.com/JuliaTesting/Aqua.jl/pull/221))
+- In `test_deps_compat`, the two subtests `check_extras` and `check_weakdeps` are now run by default. ([#202](https://github.com/JuliaTesting/Aqua.jl/pull/202)) [BREAKING]
 
 
 ## [0.7.4] - 2023-10-24

--- a/src/deps_compat.jl
+++ b/src/deps_compat.jl
@@ -10,9 +10,9 @@ each package listed under `deps`.
 
 # Keyword Arguments
 ## Test choosers
-- `check_extras = false`: If true, additionally check "extras". A NamedTuple
+- `check_extras = true`: If true, additionally check "extras". A NamedTuple
   can be used to pass keyword arguments with test options (see below).
-- `check_weakdeps = false`: If true, additionally check "weakdeps". A NamedTuple
+- `check_weakdeps = true`: If true, additionally check "weakdeps". A NamedTuple
   can be used to pass keyword arguments with test options (see below).
 
 ## Test options
@@ -23,12 +23,7 @@ to the corresponding `check_\$x` keyword argument.
   `@test` for "deps".
 - `ignore::Vector{Symbol}`: names of dependent packages to be ignored.
 """
-function test_deps_compat(
-    pkg::PkgId;
-    check_extras = false,     # Maybe switch to `true` for next breaking version
-    check_weakdeps = false,   # Maybe switch to `true` for next breaking version
-    kwargs...,
-)
+function test_deps_compat(pkg::PkgId; check_extras = true, check_weakdeps = true, kwargs...)
     @testset "$pkg deps" begin
         test_deps_compat(pkg, "deps"; kwargs...)
     end

--- a/test/test_smoke.jl
+++ b/test/test_smoke.jl
@@ -13,7 +13,7 @@ Aqua.test_all(
     undefined_exports = false,
     project_extras = false,
     stale_deps = false,
-    deps_compat = (; check_extras = true, check_weakdeps = true),
+    deps_compat = false,
     project_toml_formatting = false,
     piracy = false,
 )


### PR DESCRIPTION
This should only be merged once a breaking release is staged. 

As this builds upon https://github.com/JuliaTesting/Aqua.jl/pull/200, that one has to be merged first.