### PR TITLE
Skip Project formatting on Julia <1.7 if there are weakdeps

### DIFF
--- a/src/project_toml_formatting.jl
+++ b/src/project_toml_formatting.jl
@@ -48,7 +48,13 @@ function _analyze_project_toml_formatting_2(path::AbstractString, original)
 
     prj = TOML.parse(original)
     formatted = sprint(print_project, prj)
-    if splitlines(original) == splitlines(formatted)
+    if VERSION < v"1.7" && (haskey(prj, "weakdeps") || haskey(prj, "extensions"))
+        LazyTestResult(
+            label,
+            "The file `$(path)` has not been tested because it has weak dependencies and Julia is in version $VERSION < 1.7.",
+            true,
+        )
+    elseif splitlines(original) == splitlines(formatted)
         LazyTestResult(label, "The file `$(path)` is in canonical format.", true)
     else
         diff = format_diff(

--- a/test/test_project_toml_formatting.jl
+++ b/test/test_project_toml_formatting.jl
@@ -76,6 +76,36 @@ using Test
         @test t ⊜ false
         @test occursin("is not in canonical format", string(t))
     end
+    @testset "pass: weakdeps + extensions following Pkg >= 1.7" begin
+        @test _analyze_project_toml_formatting_2(
+            path,
+            """
+            name = "Aqua"
+            uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
+            authors = ["Takafumi Arakaki <aka.tkf@gmail.com>"]
+            version = "0.4.7-DEV"
+
+            [deps]
+            Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+            Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+            [weakdeps]
+            Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+            [extensions]
+            AquaRandomExt = "Random"
+
+            [compat]
+            julia = "1.0"
+
+            [extras]
+            Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+            [targets]
+            test = ["Test"]
+            """,
+        ) ⊜ true
+    end
 end
 
 end  # module


### PR DESCRIPTION
Brutal fix for https://github.com/JuliaTesting/Aqua.jl/issues/208. If the Julia version is below 1.7 and the `Project.toml` contains `weakdeps` or `extensions`, its formatting test will now return `true` by default.
This only affects people who write package extensions, and my assumption is that those people test on 1.9 and above anyway.

See also https://github.com/JuliaLang/Pkg.jl/issues/3481

Ping @adrhill

closes #209, closes #210
