### PR TITLE
Release version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2023-11-15
+
 ### Added
 
 - Two additions check whether packages might block precompilation on Julia 1.10 or higher: ([#174](https://github.com/JuliaTesting/Aqua.jl/pull/174))
-  + `test_persistent_tasks` tests whether "your" package can safely be used as a dependency for downstream packages. This test is enabled for the default testsuite, but you can opt-out by supplying `persistent_tasks=false` to `test_all`. [BREAKING]
+  + `test_persistent_tasks` tests whether "your" package can safely be used as a dependency for downstream packages. This test is enabled for the default testsuite `test_all`, but you can opt-out by supplying `persistent_tasks=false` to `test_all`. [BREAKING]
   + `find_persistent_tasks_deps` is useful if "your" package hangs upon precompilation: it runs `test_persistent_tasks` on all the things you depend on, and may help isolate the culprit(s).
 
 ### Changed
 
-- `test_ambiguities` now excludes the keyword sorter of all `exclude`d functions with keyword arguments as well. ([#203](https://github.com/JuliaTesting/Aqua.jl/pull/204))
 - In `test_deps_compat`, the two subtests `check_extras` and `check_weakdeps` are now run by default. ([#202](https://github.com/JuliaTesting/Aqua.jl/pull/202)) [BREAKING]
 - `test_deps_compat` now reqiures compat entries for all dependencies. Stdlibs no longer get ignored. This change is motivated by similar changes in the General registry. ([#215](https://github.com/JuliaTesting/Aqua.jl/pull/215)) [BREAKING]
-- `test_deps_compat` now requires a compat entry for `julia` This can be disabling by setting `compat_julia = false`. ([#236](https://github.com/JuliaTesting/Aqua.jl/pull/236)) [BREAKING]
+- `test_ambiguities` now excludes the keyword sorter of all `exclude`d functions with keyword arguments as well. ([#203](https://github.com/JuliaTesting/Aqua.jl/pull/204))
 - `test_piracy` is renamed to `test_piracies`. ([#230](https://github.com/JuliaTesting/Aqua.jl/pull/230)) [BREAKING]
 - `test_ambiguities` and `test_piracies` now return issues in a defined order. This order may change in a patch release of Aqua.jl. ([#233](https://github.com/JuliaTesting/Aqua.jl/pull/233))
-- Improved the message for `test_project_extras` failures. ([#233](https://github.com/JuliaTesting/Aqua.jl/pull/233))
+- Improved the message for `test_project_extras` failures. ([#234](https://github.com/JuliaTesting/Aqua.jl/pull/234))
+- `test_deps_compat` now requires a compat entry for `julia` This can be disabling by setting `compat_julia = false`. ([#236](https://github.com/JuliaTesting/Aqua.jl/pull/236)) [BREAKING]
 
 ### Removed
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Aqua"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
-version = "0.8.0-DEV"
+version = "0.8.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@ Aqua.jl provides functions to run a few automatable checks for Julia packages:
 * There are no undefined `export`s.
 * There are no unbound type parameters.
 * There are no stale dependencies listed in `Project.toml`.
-* Check that test target of the root project `Project.toml` and test project
-  (`test/Project.toml`) are consistent.
-* Check that all external packages listed in `deps` have corresponding
-  `compat` entry.
+* Check that test target of the root project `Project.toml` and test project (`test/Project.toml`) are consistent.
+* Check that all external packages listed in `deps` have corresponding `compat` entries.
 * There are no "obvious" type piracies.
+* The package does not create any persistent Tasks that might block precompilation of dependencies.
 
 See more in the [documentation](https://juliatesting.github.io/Aqua.jl/).
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,10 +7,8 @@ Aqua.jl provides functions to run a few automatable checks for Julia packages:
 * There are no undefined `export`s.
 * There are no unbound type parameters.
 * There are no stale dependencies listed in `Project.toml`.
-* Check that test target of the root project `Project.toml` and test project
-  (`test/Project.toml`) are consistent.
-* Check that all external packages listed in `deps` have corresponding
-  `compat` entry.
+* Check that test target of the root project `Project.toml` and test project (`test/Project.toml`) are consistent.
+* Check that all external packages listed in `deps` have corresponding `compat` entries.
 * There are no "obvious" type piracies.
 * The package does not create any persistent Tasks that might block precompilation of dependencies.
 
@@ -78,15 +76,14 @@ using Aqua
   Aqua.test_all(
     YourPackage;
     ambiguities=(exclude=[SomePackage.some_function], broken=true),
-    unbound_args=true,
-    undefined_exports=true,
-    project_extras=true,
     stale_deps=(ignore=[:SomePackage],),
     deps_compat=(ignore=[:SomeOtherPackage],),
     piracies=false,
   )
 end
 ```
+Note, that for all tests with no explicit options provided, the default options are used.
+
 For more details on the options, see the respective functions [below](@ref test_functions).
 
 ### Example uses

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -37,13 +37,13 @@ recommended to add a version bound for Aqua.jl.
     Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
     [compat]
-    Aqua = "0.7"
+    Aqua = "0.8"
     ```
 
  2. In `YourPackage/Project.toml`, add Aqua.jl to `[compat]` and `[extras]` section and the `test` target, like
     ```toml
     [compat]
-    Aqua = "0.7"
+    Aqua = "0.8"
 
     [extras]
     Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
This makes all necessary changes after a merge of https://github.com/JuliaTesting/Aqua.jl/pull/236 to release version 0.8.0.