### PR TITLE
Require `[compat]` entry for `julia`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `test_ambiguities` now excludes the keyword sorter of all `exclude`d functions with keyword arguments as well. ([#203](https://github.com/JuliaTesting/Aqua.jl/pull/204))
 - In `test_deps_compat`, the two subtests `check_extras` and `check_weakdeps` are now run by default. ([#202](https://github.com/JuliaTesting/Aqua.jl/pull/202)) [BREAKING]
 - `test_deps_compat` now reqiures compat entries for all dependencies. Stdlibs no longer get ignored. This change is motivated by similar changes in the General registry. ([#215](https://github.com/JuliaTesting/Aqua.jl/pull/215)) [BREAKING]
+- `test_deps_compat` now requires a compat entry for `julia` This can be disabling by setting `compat_julia = false`. ([#236](https://github.com/JuliaTesting/Aqua.jl/pull/236)) [BREAKING]
 - `test_piracy` is renamed to `test_piracies`. ([#230](https://github.com/JuliaTesting/Aqua.jl/pull/230)) [BREAKING]
 - `test_ambiguities` and `test_piracies` now return issues in a defined order. This order may change in a patch release of Aqua.jl. ([#233](https://github.com/JuliaTesting/Aqua.jl/pull/233))
 - Improved the message for `test_project_extras` failures. ([#233](https://github.com/JuliaTesting/Aqua.jl/pull/233))

--- a/test/test_deps_compat.jl
+++ b/test/test_deps_compat.jl
@@ -1,9 +1,31 @@
 module TestDepsCompat
 
 include("preamble.jl")
-using Aqua: find_missing_deps_compat
+using Aqua: find_missing_deps_compat, has_julia_compat
 
 const DictSA = Dict{String,Any}
+
+@testset "has_julia_compat" begin
+    @test has_julia_compat(DictSA("compat" => DictSA("julia" => "1")))
+    @test has_julia_compat(DictSA("compat" => DictSA("julia" => "1.0")))
+    @test has_julia_compat(DictSA("compat" => DictSA("julia" => "1.6")))
+    @test has_julia_compat(
+        DictSA(
+            "deps" => DictSA("PkgA" => "229717a1-0d13-4dfb-ba8f-049672e31205"),
+            "compat" => DictSA("julia" => "1", "PkgA" => "1.0"),
+        ),
+    )
+
+    @test !has_julia_compat(DictSA())
+    @test !has_julia_compat(DictSA("compat" => DictSA()))
+    @test !has_julia_compat(DictSA("compat" => DictSA("PkgA" => "1.0")))
+    @test !has_julia_compat(
+        DictSA(
+            "deps" => DictSA("PkgA" => "229717a1-0d13-4dfb-ba8f-049672e31205"),
+            "compat" => DictSA("PkgA" => "1.0"),
+        ),
+    )
+end
 
 @testset "find_missing_deps_compat" begin
     @testset "pass" begin
@@ -12,6 +34,7 @@ const DictSA = Dict{String,Any}
             "deps",
         )
         @test isempty(result)
+
         result = find_missing_deps_compat(
             DictSA(
                 "deps" => DictSA("PkgA" => "229717a1-0d13-4dfb-ba8f-049672e31205"),


### PR DESCRIPTION
Resolves https://github.com/JuliaTesting/Aqua.jl/issues/235.

As this is point 7 in the [guidelines for the General registry](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/#New-packages), I support Aqua checking this.