### PR TITLE
Fix environments in `test_persistent_tasks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.8.1] - 2023-11-16
+
+### Changed
+
+- `test_persistent_tasks` now redirects stdout and stderr of the created subtask. Furthermore, the environment of the subtask gets cleared to allow default values for `JULIA_LOAD_PATH` to work. ([#240](https://github.com/JuliaTesting/Aqua.jl/pull/240))
+
+
 ## [0.8.0] - 2023-11-15
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Aqua"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/persistent_tasks.jl
+++ b/src/persistent_tasks.jl
@@ -152,7 +152,8 @@ end
         end
         # Precompile the wrapper package
         cmd = `$(Base.julia_cmd()) --project=$wrapperdir -e 'using Pkg; Pkg.precompile()'`
-        proc = run(cmd; wait = false)
+        cmd = setenv(cmd, String[])
+        proc = run(cmd, stdin, stdout, stderr; wait = false)
         while !isfile(statusfile) && process_running(proc)
             sleep(0.5)
         end


### PR DESCRIPTION
On the CI testing setup of AbstractAlgebra.jl, I got the following error in the sub-process of `test_persistent_tasks`. ([log](https://github.com/Nemocas/AbstractAlgebra.jl/actions/runs/6889627119/job/18741007773?pr=1500#step:6:182))
```
ERROR: ArgumentError: Package Pkg not found in current path.
- Run `import Pkg; Pkg.add("Pkg")` to install the Pkg package.
```
After some digging around, I found that `LOAD_PATH` was just `["@", "/tmp/jl_yzJAOE"]` there, so that's the reason why `Pkg` could not be found. The easiest (and only) solution I could find, was to clear the ENV of the sub-process explicitly to allow a default value for `LOAD_PATH` to populate (see https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_LOAD_PATH).

Furthermore, this PR allows errors in the sub-process to show up in the stderr of the main process.