### PR TITLE
Increase CI timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         os: ["ubuntu-latest"]


### PR DESCRIPTION
Some jobs occasionally fail due to a timeout. A small increase could help with that.