### PR TITLE
persistent_tasks: suppress logs from Pkg.jl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3] - 2023-11-29
+
+## Changed
+
+- `test_persistent_tasks` is now less noisy. ([#256](https://github.com/JuliaTesting/Aqua.jl/pull/256))
+
 
 ## [0.8.2] - 2023-11-16
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Aqua"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/persistent_tasks.jl
+++ b/src/persistent_tasks.jl
@@ -167,7 +167,7 @@ end
         end
         success = !process_running(proc)
         if !success
-            kill(proc)
+            kill(proc, Base.SIGKILL)
         end
         return success
     finally


### PR DESCRIPTION
By using `io=devnull` option, which is only available in Julia 1.9 and above.