### PR TITLE
Update stale deps stdlibs known bug warning

### DIFF
--- a/src/stale_deps.jl
+++ b/src/stale_deps.jl
@@ -12,13 +12,6 @@ directly, this can be achieved via transitivity as well.
     not check if a package extension indeed loads all of its trigger
     dependencies using `import` or `using`. 
 
-!!! warning "Known bug"
-
-    Currently, `Aqua.test_stale_deps` does not detect stale
-    dependencies when they are stdlib.  This is considered a bug and
-    may be fixed in the future.  Such a release is considered
-    non-breaking.
-
 # Arguments
 - `packages`: a top-level `Module`, a `Base.PkgId`, or a collection of
   them.

--- a/src/stale_deps.jl
+++ b/src/stale_deps.jl
@@ -12,6 +12,12 @@ directly, this can be achieved via transitivity as well.
     not check if a package extension indeed loads all of its trigger
     dependencies using `import` or `using`. 
 
+!!! warning "Known bug"
+    Currently, `Aqua.test_stale_deps` does not detect stale
+    dependencies when they are in the sysimage. This is considered a 
+    bug and may be fixed in the future. Such a release is considered
+    non-breaking.
+
 # Arguments
 - `packages`: a top-level `Module`, a `Base.PkgId`, or a collection of
   them.

--- a/src/stale_deps.jl
+++ b/src/stale_deps.jl
@@ -13,6 +13,7 @@ directly, this can be achieved via transitivity as well.
     dependencies using `import` or `using`. 
 
 !!! warning "Known bug"
+
     Currently, `Aqua.test_stale_deps` does not detect stale
     dependencies when they are in the sysimage. This is considered a 
     bug and may be fixed in the future. Such a release is considered


### PR DESCRIPTION
I just got this error

```
Stale dependencies: Test Failed at /home/x/.julia/packages/Aqua/9p8ck/src/stale_deps.jl:31
  Expression: isempty(stale_deps)
   Evaluated: isempty(Base.PkgId[Base.PkgId(Base.UUID("9e88b42a-f829-5b0c-bbe9-9e923198166b"), "Serialization")])
```

So I think this bug is fixed.

Would tests be expected for this PR?