### PR TITLE
Make broken tests less noisy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- When supplying `broken = true` to `test_ambiguities`, `test_undefined_exports`, `test_piracies`, or `test_unbound_args`, the output is shortened. In particular, the list of offending instances is no longer printed. To get the full output, set `broken = false`. ([#272](https://github.com/JuliaTesting/Aqua.jl/pull/272))
+
+
 ## [0.8.4] - 2023-12-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- When supplying `broken = true` to `test_ambiguities`, `test_undefined_exports`, `test_piracies`, or `test_unbound_args`, the output is shortened. In particular, the list of offending instances is no longer printed. To get the full output, set `broken = false`. ([#272](https://github.com/JuliaTesting/Aqua.jl/pull/272))
+- When supplying `broken = true` to `test_ambiguities`, `test_undefined_exports`, `test_piracies`, or `test_unbound_args`, the output is shortened. In particular, the list of offending instances is no longer printed. To get the full output, set `broken = false`. ([#272])
 - Use [Changelog.jl](https://github.com/JuliaDocs/Changelog.jl) to generate the changelog, and add it to the documentation. ([#277])
 - `test_project_extras` prints failures the same on all julia versions. In particular, 1.11 and nightly are no outliers. ([#275])
 
@@ -251,5 +251,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#250]: https://github.com/JuliaTesting/Aqua.jl/issues/250
 [#255]: https://github.com/JuliaTesting/Aqua.jl/issues/255
 [#256]: https://github.com/JuliaTesting/Aqua.jl/issues/256
+[#272]: https://github.com/JuliaTesting/Aqua.jl/issues/272
 [#275]: https://github.com/JuliaTesting/Aqua.jl/issues/275
 [#277]: https://github.com/JuliaTesting/Aqua.jl/issues/277

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -29,12 +29,31 @@ Test that all `export`ed names in `module` actually exist.
 
 # Keyword Arguments
 - `broken::Bool = false`: If true, it uses `@test_broken` instead of
-  `@test`.
+  `@test` and shortens the error message.
 """
 function test_undefined_exports(m::Module; broken::Bool = false)
+    exports = undefined_exports(m)
     if broken
-        @test_broken undefined_exports(m) == []
+        if !isempty(exports)
+            printstyled(
+                stderr,
+                "$(length(exports)) undefined exports detected. To get a list, set `broken = false`.\n";
+                bold = true,
+                color = Base.error_color(),
+            )
+        end
+        @test_broken isempty(exports)
     else
-        @test undefined_exports(m) == []
+        if !isempty(exports)
+            printstyled(
+                stderr,
+                "Undefined exports detected:\n";
+                bold = true,
+                color = Base.error_color(),
+            )
+            show(stderr, MIME"text/plain"(), exports)
+            println(stderr)
+        end
+        @test isempty(exports)
     end
 end

--- a/src/piracies.jl
+++ b/src/piracies.jl
@@ -206,7 +206,7 @@ Test that `m` does not commit type piracies.
 
 # Keyword Arguments
 - `broken::Bool = false`: If true, it uses `@test_broken` instead of
-  `@test`.
+  `@test` and shortens the error message.
 - `skip_deprecated::Bool = true`: If true, it does not check deprecated methods.
 - `treat_as_own = Union{Function, Type}[]`: The types in this container 
   are considered to be "owned" by the module `m`. This is useful for 
@@ -216,19 +216,27 @@ Test that `m` does not commit type piracies.
 """
 function test_piracies(m::Module; broken::Bool = false, kwargs...)
     v = Piracy.hunt(m; kwargs...)
-    if !isempty(v)
-        printstyled(
-            stderr,
-            "Possible type-piracy detected:\n";
-            bold = true,
-            color = Base.error_color(),
-        )
-        show(stderr, MIME"text/plain"(), v)
-        println(stderr)
-    end
     if broken
+        if !isempty(v)
+            printstyled(
+                stderr,
+                "$(length(v)) instances of possible type-piracy detected. To get a list, set `broken = false`.\n";
+                bold = true,
+                color = Base.error_color(),
+            )
+        end
         @test_broken isempty(v)
     else
+        if !isempty(v)
+            printstyled(
+                stderr,
+                "Possible type-piracy detected:\n";
+                bold = true,
+                color = Base.error_color(),
+            )
+            show(stderr, MIME"text/plain"(), v)
+            println(stderr)
+        end
         @test isempty(v)
     end
 end

--- a/src/unbound_args.jl
+++ b/src/unbound_args.jl
@@ -8,23 +8,32 @@ of the method.
 
 # Keyword Arguments
 - `broken::Bool = false`: If true, it uses `@test_broken` instead of
-  `@test`.
+  `@test` and shortens the error message.
 """
 function test_unbound_args(m::Module; broken::Bool = false)
     unbounds = detect_unbound_args_recursively(m)
-    if !isempty(unbounds)
-        printstyled(
-            stderr,
-            "Unbound type parameters detected:\n";
-            bold = true,
-            color = Base.error_color(),
-        )
-        show(stderr, MIME"text/plain"(), unbounds)
-        println(stderr)
-    end
     if broken
+        if !isempty(unbounds)
+            printstyled(
+                stderr,
+                "$(length(unbounds)) instances of unbound type parameters detected. To get a list, set `broken = false`.\n";
+                bold = true,
+                color = Base.error_color(),
+            )
+        end
         @test_broken isempty(unbounds)
     else
+        if !isempty(unbounds)
+            printstyled(
+                stderr,
+                "Unbound type parameters detected:\n";
+                bold = true,
+                color = Base.error_color(),
+            )
+            show(stderr, MIME"text/plain"(), unbounds)
+            println(stderr)
+        end
+
         @test isempty(unbounds)
     end
 end


### PR DESCRIPTION
Resolves https://github.com/JuliaTesting/Aqua.jl/issues/231.

The tests that may print long lists of things now only do that in the case of a failure. If the test is supplied `broken=true`, only the number of instances is printed instead.