### PR TITLE
Use custom printing of UUIDs instead of relying on Base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `test_project_extras` prints failures the same on all julia versions. In particular, 1.11 and nightly are no outliers. ([#275](https://github.com/JuliaTesting/Aqua.jl/pull/275))
+
+
 ## [0.8.4] - 2023-12-01
 
 ### Added

--- a/src/project_extras.jl
+++ b/src/project_extras.jl
@@ -73,15 +73,15 @@ function analyze_project_extras(pkg::PkgId)
         )
         if !isempty(not_in_extras)
             msg = "Test dependencies not in root project ($root_project_path):"
-            for pkgs in sort!(collect(not_in_extras); by = (pkg -> pkg.name))
-                msg *= "\n\t$pkgs"
+            for pkg in sort!(collect(not_in_extras); by = (pkg -> pkg.name))
+                msg *= "\n\t$(pkg.name) [$(pkg.uuid)]"
             end
             push!(msgs, msg)
         end
         if !isempty(not_in_test)
             msg = "Dependencies not in test project ($test_project_path):"
-            for pkgs in sort!(collect(not_in_test); by = (pkg -> pkg.name))
-                msg *= "\n\t$pkgs"
+            for pkg in sort!(collect(not_in_test); by = (pkg -> pkg.name))
+                msg *= "\n\t$(pkg.name) [$(pkg.uuid)]"
             end
             push!(msgs, msg)
         end

--- a/test/test_project_extras.jl
+++ b/test/test_project_extras.jl
@@ -30,13 +30,13 @@ with_sample_pkgs() do
         @test any(
             msg ->
                 occursin("Test dependencies not in root project", msg) &&
-                    occursin("Random [", msg),
+                    occursin("Random [9a3f8284-a2c9-5f02-9a11-845980a1fd5c]", msg),
             result,
         )
         @test any(
             msg ->
                 occursin("Dependencies not in test project", msg) &&
-                    occursin("REPL [", msg),
+                    occursin("REPL [3fa0cd96-eef1-5676-8a61-b3b8758bbffb]", msg),
             result,
         )
         @test !any(msg -> occursin("Test [", msg), result)


### PR DESCRIPTION
Julia changed the printing in https://github.com/JuliaLang/julia/pull/52795 which then made our tests fail as we check against a concrete string.

Resolves https://github.com/JuliaTesting/Aqua.jl/issues/274.