### PR TITLE
Fix failing persistent task example in doc

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Changelog = "5217a498-cd5d-4ec6-b8c2-9b85a09b6e3e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Changelog = "5217a498-cd5d-4ec6-b8c2-9b85a09b6e3e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 

--- a/docs/src/persistent_tasks.md
+++ b/docs/src/persistent_tasks.md
@@ -48,9 +48,10 @@ end)
 Here is an example test with a dummy expr which will obviously fail, because it's explicitly
 spawning a Task that never dies.
 ```@repl
-Aqua.test_persistent_tasks(Aqua, quote
+import Aqua
+Aqua.test_persistent_tasks(Aqua, expr = quote
     Threads.@spawn while true sleep(0.5) end
-end
+end)
 ```
 
 ## How the test works

--- a/docs/src/persistent_tasks.md
+++ b/docs/src/persistent_tasks.md
@@ -48,7 +48,7 @@ end)
 Here is an example test with a dummy expr which will obviously fail, because it's explicitly
 spawning a Task that never dies.
 ```@repl
-import Aqua
+using Aqua
 Aqua.test_persistent_tasks(Aqua, expr = quote
     Threads.@spawn while true sleep(0.5) end
 end)


### PR DESCRIPTION
There was a missing closing parenthesis, and `Aqua` was not being imported in the block. This PR fixes these.