### PR TITLE
Add kwarg `succeed_on_precompilable_error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `test_persistent_tasks` now accepts an optional `succeed_on_precompilable_error::Bool=true` to control the behavior on the occurrence of a `PrecompilableError`. ([#285])
+
 ### Changed
 
 - The output of `test_ambiguities` now gets printed to stderr instead of stdout. ([#281])

--- a/src/persistent_tasks.jl
+++ b/src/persistent_tasks.jl
@@ -20,6 +20,10 @@ On Julia version 1.9 and before, this test always succeeds.
 - `tmax::Real = 5`: the maximum time (in seconds) to wait after loading the
   package before forcibly shutting down the precompilation process (triggering
   a test failure).
+- `succeed_on_precompilable_error::Bool = true`: If true, the test will pass if
+  the package has a precompilation error. The intended use is to keep your CI
+  green even if the case that a new release of a dependency introduces a
+  method overwrite that breaks precompilation of your package.
 - `expr::Expr = quote end`: An expression to run in the precompile package.
 
 !!! note
@@ -43,10 +47,23 @@ function test_persistent_tasks(package::Module; kwargs...)
     test_persistent_tasks(PkgId(package); kwargs...)
 end
 
-function has_persistent_tasks(package::PkgId; expr::Expr = quote end, tmax = 10)
-    root_project_path, found = root_project_toml(package)
-    found || error("Unable to locate Project.toml")
-    return !precompile_wrapper(root_project_path, tmax, expr)
+function has_persistent_tasks(
+    package::PkgId;
+    expr::Expr = quote end,
+    succeed_on_precompilable_error::Bool = true,
+    tmax = 10,
+)
+    @static if VERSION < v"1.10.0-"
+        return false
+    else
+        if Base.compilecache(package) isa Base.PrecompilableError
+            @error "Package $(package.name) has a precompilation error"
+            return !succeed_on_precompilable_error
+        end
+        root_project_path, found = root_project_toml(package)
+        found || error("Unable to locate Project.toml")
+        return !precompile_wrapper(root_project_path, tmax, expr)
+    end
 end
 
 """
@@ -75,9 +92,6 @@ function find_persistent_tasks_deps(package::Module; kwargs...)
 end
 
 function precompile_wrapper(project, tmax, expr)
-    @static if VERSION < v"1.10.0-"
-        return true
-    end
     prev_project = Base.active_project()::String
     isdefined(Pkg, :respect_sysimage_versions) && Pkg.respect_sysimage_versions(false)
     try

--- a/test/pkgs/PersistentTasks/PrecompilableErrorPkg/Project.toml
+++ b/test/pkgs/PersistentTasks/PrecompilableErrorPkg/Project.toml
@@ -1,0 +1,2 @@
+name = "PrecompilableErrorPkg"
+uuid = "e5c298b6-d81d-47aa-a9ed-5ea983e22986"

--- a/test/pkgs/PersistentTasks/PrecompilableErrorPkg/src/PrecompilableErrorPkg.jl
+++ b/test/pkgs/PersistentTasks/PrecompilableErrorPkg/src/PrecompilableErrorPkg.jl
@@ -1,0 +1,5 @@
+module PrecompilableErrorPkg
+
+__precompile__(false)
+
+end # module PrecompilableErrorPkg


### PR DESCRIPTION
I often experience precompilable errors in development when sorting out type piracy etc., e.g. when moving functions to a dependency and thus creating method overwriting. This change let's the persistent task test succeed in the case of a precompilable error to smooth these cases, with the possibility to opt-in into getting this as a failure instead.