### PR TITLE
remove Base and Core from ambiguities test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Version [v0.8.9] - 2024-10-15
+
+### Changed
+
+- Change `test_ambiguities` to only return ambiguities that happen in the target package. ([#309])
+
+
 ## Version [v0.8.8] - 2024-10-10
 
 ### Changed
@@ -235,6 +242,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.8.6]: https://github.com/JuliaTesting/Aqua.jl/releases/tag/v0.8.6
 [v0.8.7]: https://github.com/JuliaTesting/Aqua.jl/releases/tag/v0.8.7
 [v0.8.8]: https://github.com/JuliaTesting/Aqua.jl/releases/tag/v0.8.8
+[v0.8.9]: https://github.com/JuliaTesting/Aqua.jl/releases/tag/v0.8.9
 [#93]: https://github.com/JuliaTesting/Aqua.jl/issues/93
 [#103]: https://github.com/JuliaTesting/Aqua.jl/issues/103
 [#113]: https://github.com/JuliaTesting/Aqua.jl/issues/113
@@ -283,3 +291,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#287]: https://github.com/JuliaTesting/Aqua.jl/issues/287
 [#288]: https://github.com/JuliaTesting/Aqua.jl/issues/288
 [#297]: https://github.com/JuliaTesting/Aqua.jl/issues/297
+[#309]: https://github.com/JuliaTesting/Aqua.jl/issues/309

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Aqua"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
-version = "0.8.8"
+version = "0.8.9"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -29,7 +29,7 @@ include("persistent_tasks.jl")
 
 Run the following tests:
 
-* [`test_ambiguities([testtarget, Base, Core])`](@ref test_ambiguities)
+* [`test_ambiguities([testtarget])`](@ref test_ambiguities)
 * [`test_unbound_args(testtarget)`](@ref test_unbound_args)
 * [`test_undefined_exports(testtarget)`](@ref test_undefined_exports)
 * [`test_project_extras(testtarget)`](@ref test_project_extras)
@@ -66,7 +66,7 @@ function test_all(
 )
     @testset "Method ambiguity" begin
         if ambiguities !== false
-            test_ambiguities([testtarget, Base, Core]; askwargs(ambiguities)...)
+            test_ambiguities([testtarget]; askwargs(ambiguities)...)
         end
     end
     @testset "Unbound type parameters" begin


### PR DESCRIPTION
Reporting ambiguities that cannot be fixed by the user since they are not part of the testtarget can be harmful to the user experience since they will never be useful, since at least JuliaLang/julia#36962.

Fixes #77