### PR TITLE
improve latency: specify element type explicitly in each comprehension

### DIFF
--- a/src/deps_compat.jl
+++ b/src/deps_compat.jl
@@ -120,7 +120,7 @@ function find_missing_deps_compat(
     compat = get(prj, "compat", Dict{String,Any}())
 
     missing_compat = sort!(
-        [
+        PkgId[
             d for d in map(d -> PkgId(UUID(last(d)), first(d)), collect(deps)) if
             !(d.name in keys(compat)) && !(d.name in String.(ignore))
         ];

--- a/src/persistent_tasks.jl
+++ b/src/persistent_tasks.jl
@@ -67,7 +67,7 @@ function find_persistent_tasks_deps(package::PkgId; kwargs...)
         id = PkgId(UUID(uuid), name)
         return has_persistent_tasks(id; kwargs...)
     end
-    return [name for (name, _) in deps]
+    return String[name for (name, _) in deps]
 end
 
 function find_persistent_tasks_deps(package::Module; kwargs...)

--- a/src/project_extras.jl
+++ b/src/project_extras.jl
@@ -43,11 +43,11 @@ function analyze_project_extras(pkg::PkgId)
     is_julia12_or_later(julia_version) && return String[]
 
     # `extras_test_deps`: test-only dependencies according to Project.toml
-    deps = [PkgId(UUID(v), k) for (k, v) in get(root_project, "deps", Dict{String,Any}())]
+    deps = PkgId[PkgId(UUID(v), k) for (k, v) in get(root_project, "deps", Dict{String,Any}())]
     target =
         Set{String}(get(get(root_project, "targets", Dict{String,Any}()), "test", String[]))
     extras_test_deps = setdiff(
-        [
+        PkgId[
             PkgId(UUID(v), k) for
             (k, v) in get(root_project, "extras", Dict{String,Any}()) if k in target
         ],
@@ -56,7 +56,7 @@ function analyze_project_extras(pkg::PkgId)
 
     # `test_deps`: test-only dependencies according to test/Project.toml:
     test_deps = setdiff(
-        [PkgId(UUID(v), k) for (k, v) in get(test_project, "deps", Dict{String,Any}())],
+        PkgId[PkgId(UUID(v), k) for (k, v) in get(test_project, "deps", Dict{String,Any}())],
         deps,
         [PkgId(UUID(root_project["uuid"]), root_project["name"])],
     )

--- a/src/stale_deps.jl
+++ b/src/stale_deps.jl
@@ -47,8 +47,8 @@ function find_stale_deps(pkg::PkgId; ignore::AbstractVector{Symbol} = Symbol[])
     found || error("Unable to locate Project.toml")
 
     prj = TOML.parsefile(root_project_path)
-    deps = [PkgId(UUID(v), k) for (k, v) in get(prj, "deps", Dict{String,Any}())]
-    weakdeps = [PkgId(UUID(v), k) for (k, v) in get(prj, "weakdeps", Dict{String,Any}())]
+    deps = PkgId[PkgId(UUID(v), k) for (k, v) in get(prj, "deps", Dict{String,Any}())]
+    weakdeps = PkgId[PkgId(UUID(v), k) for (k, v) in get(prj, "weakdeps", Dict{String,Any}())]
 
     marker = "_START_MARKER_"
     code = """
@@ -85,9 +85,9 @@ function find_stale_deps_2(;
     pkgid_from_uuid = Dict(p.uuid => p for p in deps)
 
     stale_uuids = setdiff(deps_uuids, loaded_uuids)
-    stale_pkgs = [pkgid_from_uuid[uuid] for uuid in stale_uuids]
+    stale_pkgs = PkgId[pkgid_from_uuid[uuid] for uuid in stale_uuids]
     stale_pkgs = setdiff(stale_pkgs, weakdeps)
-    stale_pkgs = [p for p in stale_pkgs if !(Symbol(p.name) in ignore)]
+    stale_pkgs = PkgId[p for p in stale_pkgs if !(Symbol(p.name) in ignore)]
 
     return stale_pkgs
 end


### PR DESCRIPTION
This improves latency a bit. The real motivation is as a prerequisite for potential future PRs: specifing the eltype explicitly could allow things like disabling inference, which should provide greater latency improvements.