### PR TITLE
test_unbound_args: add a functionality to ignore specific methods

### DIFF
--- a/src/unbound_args.jl
+++ b/src/unbound_args.jl
@@ -11,19 +11,19 @@ passed directly to the function instead of the module.
 # Keyword Arguments
 - `broken::Bool = false`: If true, it uses `@test_broken` instead of
   `@test` and shortens the error message.
-- `ignore::Vector{Tuple{Function, DataType...}}`: A list of functions and their
-  signatures to ignore. The signatures are given as tuples, where the
-  first element is the function and the rest are the types of the
-  arguments. For example, to ignore `foo(x::Int, y::Float64)`, pass
-  `(foo, Int, Float64)`.
+- `exclude::AbstractVector{Tuple{Function, DataType...}} = []`: A list of
+  functions and their signatures to exclude. The signatures are given as
+  tuples, where the first element is the function and the rest are the types of
+  the arguments. For example, to ignore `foo(x::Int, y::Float64)`,
+  pass `(foo, Int, Float64)`.
 """
-function test_unbound_args(m::Module; broken::Bool = false, ignore = ())
+function test_unbound_args(m::Module; broken::Bool = false, exclude = [])
     unbounds = detect_unbound_args_recursively(m)
-    for i in ignore
+    for i in exclude
         # i[2:end] is empty if length(i) == 1
-        ignore_signature = Tuple{typeof(i[1]),i[2:end]...}
+        exclude_signature = Tuple{typeof(i[1]),i[2:end]...}
         filter!(unbounds) do method
-            method.sig != ignore_signature
+            method.sig != exclude_signature
         end
     end
     test_unbound_args(unbounds; broken = broken)

--- a/src/unbound_args.jl
+++ b/src/unbound_args.jl
@@ -20,8 +20,11 @@ passed directly to the function instead of the module.
 function test_unbound_args(m::Module; broken::Bool = false, exclude = [])
     unbounds = detect_unbound_args_recursively(m)
     for i in exclude
-        # i[2:end] is empty if length(i) == 1
-        exclude_signature = Tuple{typeof(i[1]),i[2:end]...}
+        callable, args = i[1], i[2:end] # i[2:end] is empty if length(i) == 1
+
+        # the type of the function is the function itself if it is a callable object
+        callable_t = callable isa Function ? typeof(callable) : callable
+        exclude_signature = Tuple{callable_t, args...}
         filter!(unbounds) do method
             method.sig != exclude_signature
         end

--- a/src/unbound_args.jl
+++ b/src/unbound_args.jl
@@ -1,12 +1,10 @@
 """
     test_unbound_args(module::Module)
-    test_unbound_args(unbounds)
 
 Test that all methods in `module` and its submodules do not have
 unbound type parameters. An unbound type parameter is a type parameter
 with a `where`, that does not occur in the signature of some dispatch
-of the method. If unbounds methods are already known, they can be
-passed directly to the function instead of the module.
+of the method.
 
 # Keyword Arguments
 - `broken::Bool = false`: If true, it uses `@test_broken` instead of
@@ -25,14 +23,9 @@ function test_unbound_args(m::Module; broken::Bool = false, exclude = [])
         # the type of the function is the function itself if it is a callable object
         callable_t = callable isa Function ? typeof(callable) : callable
         exclude_signature = Tuple{callable_t, args...}
-        filter!(unbounds) do method
-            method.sig != exclude_signature
-        end
+        filter!(method -> (method.sig != exclude_signature), unbounds)
     end
-    test_unbound_args(unbounds; broken = broken)
-end
 
-function test_unbound_args(unbounds; broken::Bool = false)
     if broken
         if !isempty(unbounds)
             printstyled(

--- a/src/unbound_args.jl
+++ b/src/unbound_args.jl
@@ -9,21 +9,15 @@ of the method.
 # Keyword Arguments
 - `broken::Bool = false`: If true, it uses `@test_broken` instead of
   `@test` and shortens the error message.
-- `exclude::AbstractVector{Tuple{Base.Callable, DataType...}} = []`: A vector of
-  signatures of functions or callable to exclude from testing. A signature is given
-  as a tuple, where the first element is the callable and the rest are
-  the types of the arguments. For example, to exclude `foo(x::Int, y::Float64)`,
-  pass `(foo, Int, Float64)`.
+- `exclude::AbstractVector = []`: A vector of signatures of methods to exclude
+  from testing. A signature is usually of the form `Tuple{typeof(f), T1, T2, ...}`.
+  where `f` is the function and `T1, T2, ...` the type parameters. For example, the
+  signature of `f(x::Float64, y)` is `Tuple{typeof(f), Float64, Any}`.
 """
 function test_unbound_args(m::Module; broken::Bool = false, exclude = [])
     unbounds = detect_unbound_args_recursively(m)
-    for i in exclude
-        callable, args = i[1], i[2:end] # i[2:end] is empty if length(i) == 1
-
-        # the type of the function is the function itself if it is a callable object
-        callable_t = callable isa Function ? typeof(callable) : callable
-        exclude_signature = Tuple{callable_t, args...}
-        filter!(method -> (method.sig != exclude_signature), unbounds)
+    for signature in exclude
+        filter!(method -> (method.sig != signature), unbounds)
     end
 
     if broken

--- a/src/unbound_args.jl
+++ b/src/unbound_args.jl
@@ -9,10 +9,10 @@ of the method.
 # Keyword Arguments
 - `broken::Bool = false`: If true, it uses `@test_broken` instead of
   `@test` and shortens the error message.
-- `exclude::AbstractVector{Tuple{Function, DataType...}} = []`: A list of
-  functions and their signatures to exclude. The signatures are given as
-  tuples, where the first element is the function and the rest are the types of
-  the arguments. For example, to ignore `foo(x::Int, y::Float64)`,
+- `exclude::AbstractVector{Tuple{Base.Callable, DataType...}} = []`: A vector of
+  signatures of functions or callable to exclude from testing. A signature is given
+  as a tuple, where the first element is the callable and the rest are
+  the types of the arguments. For example, to exclude `foo(x::Int, y::Float64)`,
   pass `(foo, Int, Float64)`.
 """
 function test_unbound_args(m::Module; broken::Bool = false, exclude = [])

--- a/test/pkgs/PkgUnboundArgs.jl
+++ b/test/pkgs/PkgUnboundArgs.jl
@@ -7,4 +7,9 @@ end
 # `_totuple` is taken from
 # https://github.com/JuliaLang/julia/blob/48634f9f8669e1dc1be0a1589cd5be880c04055a/test/ambiguous.jl#L257-L259
 
+# taken from https://github.com/JuliaTesting/Aqua.jl/issues/86
+module Issue86
+f(::NTuple{N,T}) where {N,T} = (N, T)
+f(::Tuple{}) = (0, Any)
+end
 end  # module

--- a/test/pkgs/PkgUnboundArgs.jl
+++ b/test/pkgs/PkgUnboundArgs.jl
@@ -12,4 +12,13 @@ module Issue86
 f(::NTuple{N,T}) where {N,T} = (N, T)
 f(::Tuple{}) = (0, Any)
 end
+
+module ExcludeCallableObject
+struct Callable{U}
+    s::U
+end
+
+(::Callable{U})(::NTuple{N,T}) where {N,T,U} = (N, T, U)
+(::Callable{U})(::Tuple{}) where {U} = (0, Any, U)
+end
 end  # module

--- a/test/test_unbound_args.jl
+++ b/test/test_unbound_args.jl
@@ -15,9 +15,10 @@ using PkgUnboundArgs
 
     Aqua.test_unbound_args(
         PkgUnboundArgs,
-        ignore = [
+        exclude = [
             (PkgUnboundArgs.M25341._totuple, Type{Tuple{Vararg{E}}} where {E}, Any, Vararg),
             (PkgUnboundArgs.Issue86.f, NTuple),
+            (PkgUnboundArgs.ExcludeCallableObject.Callable, NTuple),
         ],
     )
 

--- a/test/test_unbound_args.jl
+++ b/test/test_unbound_args.jl
@@ -16,9 +16,14 @@ using PkgUnboundArgs
     Aqua.test_unbound_args(
         PkgUnboundArgs,
         exclude = [
-            (PkgUnboundArgs.M25341._totuple, Type{Tuple{Vararg{E}}} where {E}, Any, Vararg),
-            (PkgUnboundArgs.Issue86.f, NTuple),
-            (PkgUnboundArgs.ExcludeCallableObject.Callable, NTuple),
+            Tuple{
+                typeof(PkgUnboundArgs.M25341._totuple),
+                Type{Tuple{Vararg{E}}} where E,
+                Any,
+                Vararg{Any},
+            },
+            Tuple{typeof(PkgUnboundArgs.Issue86.f),NTuple},
+            Tuple{PkgUnboundArgs.ExcludeCallableObject.Callable,NTuple},
         ],
     )
 

--- a/test/test_unbound_args.jl
+++ b/test/test_unbound_args.jl
@@ -13,6 +13,14 @@ using PkgUnboundArgs
     @test length(results) == 1
     @test results[1] isa Test.Fail
 
+    Aqua.test_unbound_args(
+        PkgUnboundArgs,
+        ignore = [
+            (PkgUnboundArgs.M25341._totuple, Type{Tuple{Vararg{E}}} where {E}, Any, Vararg),
+            (PkgUnboundArgs.Issue86.f, NTuple),
+        ],
+    )
+
     # It works with other tests:
     Aqua.test_ambiguities(PkgUnboundArgs)
     Aqua.test_undefined_exports(PkgUnboundArgs)


### PR DESCRIPTION
With this PR, it is now possible to ignore some methods, given their signature. For example, taking the false positive in #86: 
```julia
module abcd

f(::NTuple{N, T}) where {N,T} = (N,T)
f(::Tuple{}) = (0,Any)

end # module
```

It is possible to disable the false positive with:
```julia
Aqua.test_unbound_args(abcd, ignore = [(abcd.f, NTuple)])
```

This specific example has been added in the unit tests.

~To improve flexibility, the possibility to call directly `Aqua.test_unbound_args(unbounds_args)` where `unbounds_args` is a collection of methods (probably got with `Test.detect_unbound_args`) is also added.~