### PR TITLE
Use more common syntax in example

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -73,7 +73,7 @@ using Aqua
 
 @testset "Aqua.jl" begin
   Aqua.test_all(
-    YourPackage;
+    YourPackage,
     ambiguities=(exclude=[SomePackage.some_function], broken=true),
     stale_deps=(ignore=[:SomePackage],),
     deps_compat=(ignore=[:SomeOtherPackage],),


### PR DESCRIPTION
This is as trivial as it will get, but using a comma "[is more common](https://docs.julialang.org/en/v1.13-dev/manual/functions/#Keyword-Arguments)" than using a semicolon, so let's use it in the official example.

I propose the change as the semicolon lead to some internal confusion/discussion here and maybe it will save others time in the future to just use the more common style.