### PR TITLE
has_persistent_tasks: use add not dev

### DIFF
--- a/src/persistent_tasks.jl
+++ b/src/persistent_tasks.jl
@@ -90,7 +90,7 @@ function precompile_wrapper(project, tmax, expr)
         wrapperdir = tempname()
         wrappername, _ = only(Pkg.generate(wrapperdir; io = devnull))
         Pkg.activate(wrapperdir; io = devnull)
-        Pkg.develop(PackageSpec(path = pkgdir); io = devnull)
+        Pkg.add(PackageSpec(path = pkgdir); io = devnull)
         statusfile = joinpath(wrapperdir, "done.log")
         open(joinpath(wrapperdir, "src", wrappername * ".jl"), "w") do io
             println(


### PR DESCRIPTION
In situations where the targeted package has a `sources` section this will try to dev the package.  Pkg then tries to find the packages indicated in sources, which will all be local paths assuming a monorepo structure, except those don't exist - because this is the stripped tarball you get from a Pkg server and not the full repo structure.

Using `add` should "just fix" that.