### PR TITLE
remove unused dependency on Compat.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,10 @@ authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
 version = "1.0.0-DEV"
 
 [deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Compat = "4"
 Pkg = "1.6"
 Test = "<0.0.1, 1"
 julia = "1.6"

--- a/test/test_smoke.jl
+++ b/test/test_smoke.jl
@@ -3,10 +3,7 @@ module TestSmoke
 using Aqua
 
 # test defaults
-Aqua.test_all(
-    Aqua;
-    stale_deps = (; ignore = [:Compat]),  # conditionally loaded
-)
+Aqua.test_all(Aqua)
 
 # test everything else
 Aqua.test_all(


### PR DESCRIPTION
This dependency has already been removed in #221. It was added again in #224. However, it has not been removed when finally updating the required Julia version in #328.

This fixes an issue found after adding a Downgrade check to RootedTrees.jl in https://github.com/SciML/RootedTrees.jl/pull/192 and https://github.com/SciML/RootedTrees.jl/pull/194.