### PR TITLE
feat!: test imports and use of private APIs through ExplicitImports.jl

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,8 +32,6 @@ jobs:
           version: 1
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-docdeploy@v1
-        with:
-          install-package: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.SSH_KEY }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,8 @@ jobs:
           version: 1
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-docdeploy@v1
+        with:
+          install-package: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.SSH_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
+        os: ["ubuntu-latest"]
         julia-version:
           - '1.12-nightly'
           - '1.11'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,21 +29,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
+        os: ['ubuntu-latest']
         julia-version:
           - '1.12-nightly'
           - '1.11'
           - '1.10'
-          - '1.9'
-          - '1.8'
-          - '1.7'
-          - '1.6'
           - 'nightly'
         include:
           - os: windows-latest
             julia-version: '1'
-          - os: windows-latest
-            julia-version: '1.6'
           - os: windows-latest
             julia-version: '1.12-nightly'
           - os: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The minimum supported julia version is increased to 1.6. ([#328])
+- Explicit imports are tested using ExplicitImports.jl ([#369])
 
 ## Version [v0.8.14] - 2025-08-04
 
@@ -41,13 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No longer call `@testset` for testsets that are skipped. ([#319])
 
-
 ## Version [v0.8.9] - 2024-10-15
 
 ### Changed
 
 - Change `test_ambiguities` to only return ambiguities that happen in the target package. ([#309])
-
 
 ## Version [v0.8.8] - 2024-10-10
 
@@ -55,18 +54,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved the documentation of `test_persisten_tasks`. ([#297])
 
-
 ## Version [v0.8.7] - 2024-04-09
 
 - Reverted [#285], which was originally released in [v0.8.6], but caused a regression. ([#287], [#288])
-
 
 ## Version [v0.8.6] - 2024-04-09
 
 ### Changed
 
 - The output of `test_ambiguities` now gets printed to stderr instead of stdout. ([#281])
-
 
 ## Version [v0.8.5] - 2024-04-03
 
@@ -76,15 +72,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use [Changelog.jl](https://github.com/JuliaDocs/Changelog.jl) to generate the changelog, and add it to the documentation. ([#277], [#279])
 - `test_project_extras` prints failures the same on all julia versions. In particular, 1.11 and nightly are no outliers. ([#275])
 
-
 ## Version [v0.8.4] - 2023-12-01
 
 ### Added
 
 - `test_persistent_tasks` now accepts an optional `expr` to run in the precompile package. ([#255])
-  + The `expr` option lets you test whether your precompile script leaves any dangling Tasks
+  - The `expr` option lets you test whether your precompile script leaves any dangling Tasks
   or Timers, which would make it unsafe to use as a dependency for downstream packages.
-
 
 ## Version [v0.8.3] - 2023-11-29
 
@@ -93,13 +87,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `test_persistent_tasks` is now less noisy. ([#256])
 - Completely overhauled the documentation. Every test now has its dedicated page. ([#250])
 
-
 ## Version [v0.8.2] - 2023-11-16
 
 ### Changed
 
 - `test_persistent_tasks` no longer clears the environment of the subtask. Instead, it modifies `LOAD_PATH` directly to make stdlibs work. ([#241])
-
 
 ## Version [v0.8.1] - 2023-11-16
 
@@ -107,14 +99,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `test_persistent_tasks` now redirects stdout and stderr of the created subtask. Furthermore, the environment of the subtask gets cleared to allow default values for `JULIA_LOAD_PATH` to work. ([#240])
 
-
 ## Version [v0.8.0] - 2023-11-15
 
 ### Added
 
 - Two additions check whether packages might block precompilation on Julia 1.10 or higher: ([#174])
-  + `test_persistent_tasks` tests whether "your" package can safely be used as a dependency for downstream packages. This test is enabled for the default testsuite `test_all`, but you can opt-out by supplying `persistent_tasks=false` to `test_all`. [BREAKING]
-  + `find_persistent_tasks_deps` is useful if "your" package hangs upon precompilation: it runs `test_persistent_tasks` on all the things you depend on, and may help isolate the culprit(s).
+  - `test_persistent_tasks` tests whether "your" package can safely be used as a dependency for downstream packages. This test is enabled for the default testsuite `test_all`, but you can opt-out by supplying `persistent_tasks=false` to `test_all`. [BREAKING]
+  - `find_persistent_tasks_deps` is useful if "your" package hangs upon precompilation: it runs `test_persistent_tasks` on all the things you depend on, and may help isolate the culprit(s).
 
 ### Changed
 
@@ -130,7 +121,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `test_project_toml_formatting` has been removed. Thus, the kwarg `project_toml_formatting` to `test_all` no longer exists. ([#209]) [BREAKING]
 
-
 ## Version [v0.7.4] - 2023-10-24
 
 ### Added
@@ -142,7 +132,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The docstring for `test_stale_deps` explains the situation with package extensions. ([#203])
 - The logo of Aqua.jl has been updated. ([#128])
 
-
 ## Version [v0.7.3] - 2023-09-25
 
 ### Added
@@ -153,20 +142,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `test_piracy` no longer prints warnings for methods where the third argument is a `TypeVar`. ([#188])
 
-
 ## Version [v0.7.2] - 2023-09-19
 
 ### Changed
 
 - `test_undefined_exports` additionally prints the modules of the undefined exports in the failure report. ([#177])
 
-
 ## Version [v0.7.1] - 2023-09-05
 
 ### Fixed
 
 - `test_piracy` no longer reports type piracy in the kwsorter, i.e. `kwcall` should no longer appear in the report. ([#171])
-
 
 ## Version [v0.7.0] - 2023-08-29
 
@@ -184,7 +170,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `test_ambiguities` prints less unnecessary whitespace. ([#158])
 - `test_ambiguities` no longer hangs indefinitely when there are many ambiguities. ([#166])
 
-
 ## Version [v0.6.7] - 2023-09-19
 
 ### Changed
@@ -196,20 +181,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `test_ambiguities` prints less unnecessary whitespace. ([#158])
 - Fix `test_piracy` for some methods with arguments of custom subtypes of `Function`. ([#170])
 
-
 ## Version [v0.6.6] - 2023-08-24
 
 ### Fixed
 
 - `test_ambiguities` no longer hangs indefinitely when there are many ambiguities. ([#166])
 
-
 ## Version [v0.6.5] - 2023-06-26
 
 ### Fixed
 
 - Typo when calling kwargs. ([#153])
-
 
 ## Version [v0.6.4] - 2023-06-25
 
@@ -225,7 +207,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Callable objects with type parameters no longer error in `test_ambiguities`' kwarg `exclude`. ([#142])
 
-
 ## Version [v0.6.3] - 2023-06-05
 
 ### Changed
@@ -236,7 +217,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `test_deps_compat`'s kwarg `ignore` now works as intended. ([#130])
 - Weakdeps are not reported as stale by `test_stale_deps` anymore. ([#135])
-
 
 ## Version [v0.6.2] - 2023-06-02
 
@@ -254,7 +234,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `test_stale_deps` no longer fails if any of the loaded packages prints during loading. ([#113])
 - Clarified the error message of `test_unbound_args`. ([#103])
 - Clarified the error message of `test_project_toml_formatting`. ([#122])
-
 
 <!-- Links generated by Changelog.jl -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No longer call `@testset` for testsets that are skipped. ([#319])
 
+
 ## Version [v0.8.9] - 2024-10-15
 
 ### Changed
 
 - Change `test_ambiguities` to only return ambiguities that happen in the target package. ([#309])
+
 
 ## Version [v0.8.8] - 2024-10-10
 
@@ -54,15 +56,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved the documentation of `test_persisten_tasks`. ([#297])
 
+
 ## Version [v0.8.7] - 2024-04-09
 
 - Reverted [#285], which was originally released in [v0.8.6], but caused a regression. ([#287], [#288])
+
 
 ## Version [v0.8.6] - 2024-04-09
 
 ### Changed
 
 - The output of `test_ambiguities` now gets printed to stderr instead of stdout. ([#281])
+
 
 ## Version [v0.8.5] - 2024-04-03
 
@@ -77,8 +82,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `test_persistent_tasks` now accepts an optional `expr` to run in the precompile package. ([#255])
-  - The `expr` option lets you test whether your precompile script leaves any dangling Tasks
+  + The `expr` option lets you test whether your precompile script leaves any dangling Tasks
   or Timers, which would make it unsafe to use as a dependency for downstream packages.
+
 
 ## Version [v0.8.3] - 2023-11-29
 
@@ -87,11 +93,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `test_persistent_tasks` is now less noisy. ([#256])
 - Completely overhauled the documentation. Every test now has its dedicated page. ([#250])
 
+
 ## Version [v0.8.2] - 2023-11-16
 
 ### Changed
 
 - `test_persistent_tasks` no longer clears the environment of the subtask. Instead, it modifies `LOAD_PATH` directly to make stdlibs work. ([#241])
+
 
 ## Version [v0.8.1] - 2023-11-16
 
@@ -99,13 +107,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `test_persistent_tasks` now redirects stdout and stderr of the created subtask. Furthermore, the environment of the subtask gets cleared to allow default values for `JULIA_LOAD_PATH` to work. ([#240])
 
+
 ## Version [v0.8.0] - 2023-11-15
 
 ### Added
 
 - Two additions check whether packages might block precompilation on Julia 1.10 or higher: ([#174])
-  - `test_persistent_tasks` tests whether "your" package can safely be used as a dependency for downstream packages. This test is enabled for the default testsuite `test_all`, but you can opt-out by supplying `persistent_tasks=false` to `test_all`. [BREAKING]
-  - `find_persistent_tasks_deps` is useful if "your" package hangs upon precompilation: it runs `test_persistent_tasks` on all the things you depend on, and may help isolate the culprit(s).
+  + `test_persistent_tasks` tests whether "your" package can safely be used as a dependency for downstream packages. This test is enabled for the default testsuite `test_all`, but you can opt-out by supplying `persistent_tasks=false` to `test_all`. [BREAKING]
+  + `find_persistent_tasks_deps` is useful if "your" package hangs upon precompilation: it runs `test_persistent_tasks` on all the things you depend on, and may help isolate the culprit(s).
 
 ### Changed
 
@@ -121,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `test_project_toml_formatting` has been removed. Thus, the kwarg `project_toml_formatting` to `test_all` no longer exists. ([#209]) [BREAKING]
 
+
 ## Version [v0.7.4] - 2023-10-24
 
 ### Added
@@ -132,6 +142,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The docstring for `test_stale_deps` explains the situation with package extensions. ([#203])
 - The logo of Aqua.jl has been updated. ([#128])
 
+
 ## Version [v0.7.3] - 2023-09-25
 
 ### Added
@@ -142,17 +153,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `test_piracy` no longer prints warnings for methods where the third argument is a `TypeVar`. ([#188])
 
+
 ## Version [v0.7.2] - 2023-09-19
 
 ### Changed
 
 - `test_undefined_exports` additionally prints the modules of the undefined exports in the failure report. ([#177])
 
+
 ## Version [v0.7.1] - 2023-09-05
 
 ### Fixed
 
 - `test_piracy` no longer reports type piracy in the kwsorter, i.e. `kwcall` should no longer appear in the report. ([#171])
+
 
 ## Version [v0.7.0] - 2023-08-29
 
@@ -170,6 +184,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `test_ambiguities` prints less unnecessary whitespace. ([#158])
 - `test_ambiguities` no longer hangs indefinitely when there are many ambiguities. ([#166])
 
+
 ## Version [v0.6.7] - 2023-09-19
 
 ### Changed
@@ -181,17 +196,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `test_ambiguities` prints less unnecessary whitespace. ([#158])
 - Fix `test_piracy` for some methods with arguments of custom subtypes of `Function`. ([#170])
 
+
 ## Version [v0.6.6] - 2023-08-24
 
 ### Fixed
 
 - `test_ambiguities` no longer hangs indefinitely when there are many ambiguities. ([#166])
 
+
 ## Version [v0.6.5] - 2023-06-26
 
 ### Fixed
 
 - Typo when calling kwargs. ([#153])
+
 
 ## Version [v0.6.4] - 2023-06-25
 
@@ -207,6 +225,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Callable objects with type parameters no longer error in `test_ambiguities`' kwarg `exclude`. ([#142])
 
+
 ## Version [v0.6.3] - 2023-06-05
 
 ### Changed
@@ -217,6 +236,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `test_deps_compat`'s kwarg `ignore` now works as intended. ([#130])
 - Weakdeps are not reported as stale by `test_stale_deps` anymore. ([#135])
+
 
 ## Version [v0.6.2] - 2023-06-02
 
@@ -234,6 +254,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `test_stale_deps` no longer fails if any of the loaded packages prints during loading. ([#113])
 - Clarified the error message of `test_unbound_args`. ([#103])
 - Clarified the error message of `test_project_toml_formatting`. ([#122])
+
 
 <!-- Links generated by Changelog.jl -->
 

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ ExplicitImports = "1.15.0"
 Pkg = "1.6"
 TOML = "1.0.3"
 Test = "<0.0.1, 1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,15 @@ authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
 version = "1.0.0-DEV"
 
 [deps]
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+ExplicitImports = "1.15.0"
 Pkg = "1.6"
+TOML = "1.0.3"
 Test = "<0.0.1, 1"
 julia = "1.6"
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,13 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Changelog = "5217a498-cd5d-4ec6-b8c2-9b85a09b6e3e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 
 [compat]
 Changelog = "1"
 Documenter = "1"
+DocumenterInterLinks = "1.1.0"
+
+[sources]
+Aqua = { path = ".." }

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Changelog = "5217a498-cd5d-4ec6-b8c2-9b85a09b6e3e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
@@ -8,6 +7,3 @@ DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 Changelog = "1"
 Documenter = "1"
 DocumenterInterLinks = "1.1.0"
-
-[sources]
-Aqua = { path = ".." }

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,5 @@
 using Documenter, Aqua, Changelog
+using DocumenterInterLinks: InterLinks
 
 # Generate a Documenter-friendly changelog from CHANGELOG.md
 Changelog.generate(
@@ -6,6 +7,10 @@ Changelog.generate(
     joinpath(@__DIR__, "..", "CHANGELOG.md"),
     joinpath(@__DIR__, "src", "release-notes.md");
     repo = "JuliaTesting/Aqua.jl",
+)
+
+links = InterLinks(
+    "ExplicitImports" => "https://juliatesting.github.io/ExplicitImports.jl/stable/",
 )
 
 makedocs(;
@@ -30,9 +35,11 @@ makedocs(;
             "piracies.md",
             "persistent_tasks.md",
             "undocumented_names.md",
+            "explicit_imports.md",
         ],
         "release-notes.md",
     ],
+    plugins = [links],
 )
 
 deploydocs(; repo = "github.com/JuliaTesting/Aqua.jl", push_preview = true)

--- a/docs/src/explicit_imports.md
+++ b/docs/src/explicit_imports.md
@@ -1,0 +1,7 @@
+# Explicit imports
+
+## [Test function](@id test_explicit_imports)
+
+```@docs
+Aqua.test_explicit_imports
+```

--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -1,10 +1,13 @@
 module Aqua
 
 using Base: Docs, PkgId, UUID
-using Pkg: Pkg, TOML, PackageSpec
-using Pkg.Types: VersionSpec, semver_spec
-using Test
+using Pkg: Pkg, PackageSpec
+using Pkg.Types: VersionSpec
+using Pkg.Versions: semver_spec
+using Test: Test, @test, @test_broken, @testset, detect_ambiguities
+using TOML: TOML
 
+using ExplicitImports: ExplicitImports
 
 include("utils.jl")
 include("ambiguities.jl")
@@ -16,6 +19,7 @@ include("deps_compat.jl")
 include("piracies.jl")
 include("persistent_tasks.jl")
 include("undocumented_names.jl")
+include("explicit_imports.jl")
 
 """
     test_all(testtarget::Module)
@@ -31,6 +35,7 @@ Run the following tests on the module `testtarget`:
 * [`test_piracies(testtarget)`](@ref test_piracies)
 * [`test_persistent_tasks(testtarget)`](@ref test_persistent_tasks)
 * [`test_undocumented_names(testtarget)`](@ref test_undocumented_names)
+* [`test_explicit_imports(testtarget)`](@ref test_explicit_imports)
 
 The keyword argument `\$x` (e.g., `ambiguities`) can be used to
 control whether or not to run `test_\$x` (e.g., `test_ambiguities`).
@@ -47,6 +52,7 @@ passed to `\$x` to specify the keyword arguments for `test_\$x`.
 - `piracies = true`
 - `persistent_tasks = true`
 - `undocumented_names = false`
+- `explicit_imports = true`
 """
 function test_all(
     testtarget::Module;
@@ -59,6 +65,7 @@ function test_all(
     piracies = true,
     persistent_tasks = true,
     undocumented_names = false,
+    explicit_imports = false,
 )
     if ambiguities !== false
         @testset "Method ambiguity" begin
@@ -106,6 +113,11 @@ function test_all(
             isempty(askwargs(undocumented_names)) ||
                 error("Keyword arguments not supported")
             test_undocumented_names(testtarget; askwargs(undocumented_names)...)
+        end
+    end
+    if explicit_imports !== false
+        @testset "Explicit imports" begin
+            test_explicit_imports(testtarget; askwargs(explicit_imports)...)
         end
     end
 end

--- a/src/explicit_imports.jl
+++ b/src/explicit_imports.jl
@@ -1,0 +1,13 @@
+"""
+    test_explicit_imports(m::Module; kwargs...)
+
+Run the various tests provided by the package [ExplicitImports.jl](https://github.com/ericphanson/ExplicitImports.jl).
+
+# Keyword Arguments
+
+Same as those of the function [`ExplicitImports.test_explicit_imports`](@extref). 
+"""
+function test_explicit_imports(m::Module; kwargs...)
+    # TODO: explicitly list kwargs here?
+    ExplicitImports.test_explicit_imports(m; kwargs...)
+end

--- a/test/test_smoke.jl
+++ b/test/test_smoke.jl
@@ -34,17 +34,24 @@ private_qualified_accesses_aquapiracy = (
     :visit, # Base
 )
 
-explicit_imports_param_for_aqua = (;
-    all_explicit_imports_are_public = (;
-        ignore = (private_explicit_imports_aqua..., private_explicit_imports_aquapiracy...)
-    ),
-    all_qualified_accesses_are_public = (;
-        ignore = (
-            private_qualified_accesses_aqua...,
-            private_qualified_accesses_aquapiracy...,
-        )
-    ),
-)
+explicit_imports_param_for_aqua = @static if VERSION < v"1.12"
+    false  # some symbols were only made public in more recent versions of Julia, the list above is for 1.12
+else
+    (;
+        all_explicit_imports_are_public = (;
+            ignore = (
+                private_explicit_imports_aqua...,
+                private_explicit_imports_aquapiracy...,
+            )
+        ),
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                private_qualified_accesses_aqua...,
+                private_qualified_accesses_aquapiracy...,
+            )
+        ),
+    )
+end
 
 Aqua.test_all(Aqua; explicit_imports = explicit_imports_param_for_aqua)
 

--- a/test/test_smoke.jl
+++ b/test/test_smoke.jl
@@ -3,7 +3,50 @@ module TestSmoke
 using Aqua
 
 # test defaults
-Aqua.test_all(Aqua)
+
+# TODO: fix instead of ignoring
+private_explicit_imports_aqua = (:PkgId,) # Base
+private_explicit_imports_aquapiracy = (:is_in_mods,) # Test
+private_qualified_accesses_aqua = (
+    :JLOptions, # Base
+    :PkgId, # Base
+    :SIGKILL, # Base
+    :error_color, # Base
+    :eval, # Base
+    :isbindingresolved, # Base
+    :isdeprecated, # Base
+    :julia_cmd, # Base
+    :kwcall, # Core
+    :kwftype, # Core
+    :load_path_setup_code, # Base
+    :morespecific, # Base
+    :require, # Base
+    :respect_sysimage_versions, # Pkg
+    :show_tuple_as_call, # Base
+    :unwrap_unionall, # Base,
+)
+private_qualified_accesses_aquapiracy = (
+    :MethodTable, # Core
+    :TypeofVararg, # Core
+    :loaded_modules_array, # Base
+    :methodtable, # Core
+    :uniontypes, # Base
+    :visit, # Base
+)
+
+explicit_imports_param_for_aqua = (;
+    all_explicit_imports_are_public = (;
+        ignore = (private_explicit_imports_aqua..., private_explicit_imports_aquapiracy...)
+    ),
+    all_qualified_accesses_are_public = (;
+        ignore = (
+            private_qualified_accesses_aqua...,
+            private_qualified_accesses_aquapiracy...,
+        )
+    ),
+)
+
+Aqua.test_all(Aqua; explicit_imports = explicit_imports_param_for_aqua)
 
 # test everything else
 Aqua.test_all(
@@ -16,6 +59,8 @@ Aqua.test_all(
     deps_compat = false,
     piracies = false,
     persistent_tasks = false,
+    undocumented_names = false,
+    explicit_imports = false,
 )
 
 end  # module


### PR DESCRIPTION
Fixes #268:

- [x] Add a new `Aqua.test_explicit_imports` which forwards everything to `ExplicitImports.test_explicit_imports` (see its [documentation](https://juliatesting.github.io/ExplicitImports.jl/stable/api/#Checks-to-use-in-testing))
- [x] Add two new dependencies to Aqua: ExplicitImports and TOML, clean up some other top-level imports
- [x] Bump Julia compat lower bound to 1.10, remove CI on versions older than LTS
- [x] Ignore enough private stuff for the new test to pass on Aqua itself
- [x] Add documentation that points towards the ExplicitImports docs

Main questions:

- Is it okay to add ExplicitImports as a hard dependency? It seems necessary if we want to make this test a default one, but it constraints Julia compat.
- Is it okay to just forward all kwargs to ExplicitImports? Or do we want to change the default values for some of them? Note that activating all of these tests will probably make most packages fail the Aqua checks (but that's arguably a good thing, and that's why we put it in the breaking v1 release).
- Is the smoke test on Aqua itself sufficient for this one, since it is properly tested in its native package, or do we want specific tests for other kwargs?

Ping @ericphanson