### PR TITLE
piracies: use Base.isType for Type checks

### DIFF
--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -161,7 +161,7 @@ function trygetft(m::Method)
     sig = Base.unwrap_unionall(m.sig)::DataType
     ft = sig.parameters[is_kwcall(sig) ? 3 : 1]
     ft = Base.unwrap_unionall(ft)
-    if Base.isType(ft)
+    if isType(ft)
         ft = Base.unwrap_unionall(ft.parameters[1])
     end
     if ft isa DataType

--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -161,7 +161,7 @@ function trygetft(m::Method)
     sig = Base.unwrap_unionall(m.sig)::DataType
     ft = sig.parameters[is_kwcall(sig) ? 3 : 1]
     ft = Base.unwrap_unionall(ft)
-    if ft isa DataType && ft.name === Type.body.name
+    if Base.isType(ft)
         ft = Base.unwrap_unionall(ft.parameters[1])
     end
     if ft isa DataType

--- a/src/piracies.jl
+++ b/src/piracies.jl
@@ -4,6 +4,9 @@ using ..Aqua: is_kwcall
 
 using Test: is_in_mods
 
+_is_type(@nospecialize(T)) = Base.isType(T)
+_type_param(@nospecialize(T)) = T.parameters[1]
+
 # based on Test/Test.jl#detect_ambiguities
 # https://github.com/JuliaLang/julia/blob/v1.9.1/stdlib/Test/src/Test.jl#L1838-L1896
 function all_methods(mods::Module...; skip_deprecated::Bool = true)
@@ -54,6 +57,7 @@ end
 # Generic fallback for type parameters that are instances, like the 1 in
 # Array{T, 1}
 is_foreign(@nospecialize(x), pkg::Base.PkgId; treat_as_own) =
+    _is_type(x) ? is_foreign(_type_param(x), pkg; treat_as_own = treat_as_own) :
     is_foreign(typeof(x), pkg; treat_as_own = treat_as_own)
 
 # Symbols can be used as type params - we assume these are unique and not
@@ -91,11 +95,11 @@ is_foreign_module(mod::Module, pkg::Base.PkgId) = Base.PkgId(mod) != pkg
 function is_foreign(@nospecialize(T::DataType), pkg::Base.PkgId; treat_as_own)
     params = T.parameters
     # For Type{Foo}, we consider it to originate from the same as Foo
-    C = getfield(parentmodule(T), nameof(T))
-    if C === Type
+    if _is_type(T)
         @assert length(params) == 1
         return is_foreign(first(params), pkg; treat_as_own = treat_as_own)
     else
+        C = getfield(parentmodule(T), nameof(T))
         # Both the type itself and all of its parameters must be foreign
         return !((C in treat_as_own)::Bool) &&
                is_foreign_module(parentmodule(T), pkg) &&
@@ -138,8 +142,7 @@ end
 function is_foreign_method(@nospecialize(T::DataType), pkg::Base.PkgId; treat_as_own)
     params = T.parameters
     # For Type{Foo}, we consider it to originate from the same as Foo
-    C = getfield(parentmodule(T), nameof(T))
-    if C === Type
+    if _is_type(T)
         @assert length(params) == 1
         return is_foreign_method(first(params), pkg; treat_as_own = treat_as_own)
     end

--- a/src/piracies.jl
+++ b/src/piracies.jl
@@ -136,6 +136,9 @@ function is_foreign_method(@nospecialize(U::Union), pkg::Base.PkgId; treat_as_ow
 end
 
 function is_foreign_method(@nospecialize(x::Any), pkg::Base.PkgId; treat_as_own)
+    if _is_type(x)
+        return is_foreign_method(_type_param(x), pkg; treat_as_own = treat_as_own)
+    end
     is_foreign(x, pkg; treat_as_own = treat_as_own)
 end
 

--- a/src/piracies.jl
+++ b/src/piracies.jl
@@ -1,10 +1,10 @@
 module Piracy
 
-using ..Aqua: is_kwcall
+using ..Aqua: is_kwcall, isType
 
 using Test: is_in_mods
 
-_is_type(@nospecialize(T)) = Base.isType(T)
+_is_type(@nospecialize(T)) = isType(T)
 _type_param(@nospecialize(T)) = T.parameters[1]
 
 # based on Test/Test.jl#detect_ambiguities

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -55,6 +55,12 @@ function checked_repr(obj)
     return code
 end
 
+@static if isdefined(Base, :isType)
+    const isType = Base.isType
+else
+    isType(@nospecialize t) = isa(t, DataType) && (t::DataType).name === Type.body.name
+end
+
 function is_kwcall(signature::Type)
     @static if VERSION < v"1.9"
         signature = Base.unwrap_unionall(signature)::DataType


### PR DESCRIPTION
Use Base.isType instead of reconstructing Type from parentmodule/nameof or Type internals when classifying method signatures. Prep for https://github.com/JuliaLang/julia/pull/61915.