### PR TITLE
[release-0.8] piracies: use Base.isType for Type checks (backport of #379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version [v0.8.15] - 2026-06-02
+
+### Changed
+
+- Use `Base.isType` for `Type{...}` checks in piracy detection so it keeps
+  working when `Type{Foo}` is no longer a `DataType` on future Julia versions.
+  ([#379])
+
 ## Version [v0.8.14] - 2025-08-04
 
 ### Changed
@@ -278,6 +286,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.8.12]: https://github.com/JuliaTesting/Aqua.jl/releases/tag/v0.8.12
 [v0.8.13]: https://github.com/JuliaTesting/Aqua.jl/releases/tag/v0.8.13
 [v0.8.14]: https://github.com/JuliaTesting/Aqua.jl/releases/tag/v0.8.14
+[v0.8.15]: https://github.com/JuliaTesting/Aqua.jl/releases/tag/v0.8.15
 [#93]: https://github.com/JuliaTesting/Aqua.jl/issues/93
 [#103]: https://github.com/JuliaTesting/Aqua.jl/issues/103
 [#113]: https://github.com/JuliaTesting/Aqua.jl/issues/113
@@ -332,3 +341,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#322]: https://github.com/JuliaTesting/Aqua.jl/issues/322
 [#334]: https://github.com/JuliaTesting/Aqua.jl/issues/334
 [#344]: https://github.com/JuliaTesting/Aqua.jl/issues/344
+[#379]: https://github.com/JuliaTesting/Aqua.jl/issues/379

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Aqua"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
-version = "0.8.14"
+version = "0.8.15"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/piracies.jl
+++ b/src/piracies.jl
@@ -1,6 +1,9 @@
 module Piracy
 
-using ..Aqua: is_kwcall
+using ..Aqua: is_kwcall, isType
+
+_is_type(@nospecialize(T)) = isType(T)
+_type_param(@nospecialize(T)) = T.parameters[1]
 
 @static if VERSION >= v"1.6-"
     using Test: is_in_mods
@@ -66,6 +69,7 @@ end
 # Generic fallback for type parameters that are instances, like the 1 in
 # Array{T, 1}
 is_foreign(@nospecialize(x), pkg::Base.PkgId; treat_as_own) =
+    _is_type(x) ? is_foreign(_type_param(x), pkg; treat_as_own = treat_as_own) :
     is_foreign(typeof(x), pkg; treat_as_own = treat_as_own)
 
 # Symbols can be used as type params - we assume these are unique and not
@@ -103,11 +107,11 @@ is_foreign_module(mod::Module, pkg::Base.PkgId) = Base.PkgId(mod) != pkg
 function is_foreign(@nospecialize(T::DataType), pkg::Base.PkgId; treat_as_own)
     params = T.parameters
     # For Type{Foo}, we consider it to originate from the same as Foo
-    C = getfield(parentmodule(T), nameof(T))
-    if C === Type
+    if _is_type(T)
         @assert length(params) == 1
         return is_foreign(first(params), pkg; treat_as_own = treat_as_own)
     else
+        C = getfield(parentmodule(T), nameof(T))
         # Both the type itself and all of its parameters must be foreign
         return !((C in treat_as_own)::Bool) &&
                is_foreign_module(parentmodule(T), pkg) &&
@@ -144,14 +148,16 @@ function is_foreign_method(@nospecialize(U::Union), pkg::Base.PkgId; treat_as_ow
 end
 
 function is_foreign_method(@nospecialize(x::Any), pkg::Base.PkgId; treat_as_own)
+    if _is_type(x)
+        return is_foreign_method(_type_param(x), pkg; treat_as_own = treat_as_own)
+    end
     is_foreign(x, pkg; treat_as_own = treat_as_own)
 end
 
 function is_foreign_method(@nospecialize(T::DataType), pkg::Base.PkgId; treat_as_own)
     params = T.parameters
     # For Type{Foo}, we consider it to originate from the same as Foo
-    C = getfield(parentmodule(T), nameof(T))
-    if C === Type
+    if _is_type(T)
         @assert length(params) == 1
         return is_foreign_method(first(params), pkg; treat_as_own = treat_as_own)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -55,6 +55,12 @@ function checked_repr(obj)
     return code
 end
 
+@static if isdefined(Base, :isType)
+    const isType = Base.isType
+else
+    isType(@nospecialize t) = isa(t, DataType) && (t::DataType).name === Type.body.name
+end
+
 function is_kwcall(signature::DataType)
     @static if VERSION < v"1.9"
         try


### PR DESCRIPTION
Backport of #379 to the 0.8 release series, plus the follow-up handling of non-DataType Type{Foo} in is_foreign_method.

Use Base.isType (with a fallback for Julia < 1.9) instead of reconstructing Type from parentmodule/nameof when classifying method signatures. This keeps piracy detection working when Type{Foo} is no longer a DataType on future Julia versions. Prep for https://github.com/JuliaLang/julia/pull/61915.

Also bump the version to 0.8.15.