### PR TITLE
Report why the persistent-tasks probe failed instead of guessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The minimum supported julia version is increased to 1.6. ([#328])
+- `test_persistent_tasks` now reports why the probe failed when its wrapper package
+  never loads, including the captured precompilation output and the subprocess exit
+  status, instead of silently attributing the failure to a persistent task.
 
 ## Version [v0.8.16] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The minimum supported julia version is increased to 1.6. ([#328])
 - `test_persistent_tasks` now reports why the probe failed when its wrapper package
   never loads, including the captured precompilation output and the subprocess exit
-  status, instead of silently attributing the failure to a persistent task.
+  status, instead of silently attributing the failure to a persistent task. ([#390])
 
 ## Version [v0.8.16] - 2026-06-05
 
@@ -358,3 +358,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#328]: https://github.com/JuliaTesting/Aqua.jl/issues/328
 [#334]: https://github.com/JuliaTesting/Aqua.jl/issues/334
 [#344]: https://github.com/JuliaTesting/Aqua.jl/issues/344
+[#390]: https://github.com/JuliaTesting/Aqua.jl/issues/390

--- a/src/persistent_tasks.jl
+++ b/src/persistent_tasks.jl
@@ -112,13 +112,26 @@ end
         end
         # Precompile the wrapper package
         currently_precompiling = @ccall(jl_generating_output()::Cint) == 1
+        # Keep `Pkg.precompile`'s chatter off the console on success, but capture it so
+        # it can be reported if the wrapper never loads. Some precompilation failures
+        # (notably the retryable "module is missing from the cache" race) only warn and
+        # exit 0, so without this the cause is lost and the package is misreported as
+        # holding a persistent task.
+        precompile_log = joinpath(wrapperdir, "precompile.log")
         cmd = if currently_precompiling
             # During precompilation we run a dummy command that just touches the
             # status file to keep things simple.
             code = """touch("$(escape_string(statusfile))")"""
             `$(Base.julia_cmd()) -e $code`
         else
-            `$(Base.julia_cmd()) --project=$wrapperdir -e 'push!(LOAD_PATH, "@stdlib"); using Pkg; Pkg.precompile(; io = devnull)'`
+            code = """
+            push!(LOAD_PATH, "@stdlib")
+            using Pkg
+            open("$(escape_string(precompile_log))", "w") do io
+                Pkg.precompile(; io = io)
+            end
+            """
+            `$(Base.julia_cmd()) --project=$wrapperdir -e $code`
         end
 
         cmd = pipeline(cmd; stdout, stderr)
@@ -127,7 +140,18 @@ end
             sleep(0.5)
         end
         if !isfile(statusfile)
-            @error "Unexpected error: $statusfile was not created, but precompilation exited"
+            wait(proc)
+            output = isfile(precompile_log) ? strip(read(precompile_log, String)) : ""
+            msg =
+                "Unexpected error: $statusfile was not created, but precompilation exited. " *
+                "This usually means the wrapper package failed to precompile, rather than " *
+                "that $pkgname holds a persistent task."
+            if isempty(output)
+                @error msg exitcode = proc.exitcode termsignal = proc.termsignal
+            else
+                @error msg exitcode = proc.exitcode termsignal = proc.termsignal precompilation =
+                    output
+            end
             return false
         end
         # Check whether precompilation finishes in the required time

--- a/test/pkgs/PersistentTasks/FailsToPrecompile/Project.toml
+++ b/test/pkgs/PersistentTasks/FailsToPrecompile/Project.toml
@@ -1,0 +1,2 @@
+name = "FailsToPrecompile"
+uuid = "3f1a9d5c-7b6e-4f2a-9c8d-1e5b7a0c4d63"

--- a/test/pkgs/PersistentTasks/FailsToPrecompile/src/FailsToPrecompile.jl
+++ b/test/pkgs/PersistentTasks/FailsToPrecompile/src/FailsToPrecompile.jl
@@ -1,0 +1,8 @@
+module FailsToPrecompile
+
+# Deliberately fails to precompile, so the persistent-tasks probe cannot load its
+# wrapper. Used to check that the probe reports the precompilation failure instead
+# of silently claiming the package holds a persistent task.
+error("FailsToPrecompile fails to precompile on purpose")
+
+end # module FailsToPrecompile

--- a/test/test_persistent_tasks.jl
+++ b/test/test_persistent_tasks.jl
@@ -29,6 +29,35 @@ end
     filter!(str -> !occursin("PersistentTasks", str), LOAD_PATH)
 end
 
+@testset "precompilation failure is reported" begin
+    if Base.VERSION >= v"1.10-"
+        # A package whose wrapper cannot precompile is not a persistent task, but the
+        # probe can only report `true`. It must at least say why, rather than leaving
+        # the caller to guess: the message names precompilation and carries the
+        # captured output.
+        msg = nothing
+        logs = Test.collect_test_logs() do
+            @test Aqua.has_persistent_tasks(getid("FailsToPrecompile"))
+        end
+        records = filter(r -> r.level == Base.CoreLogging.Error, logs[1])
+        @test !isempty(records)
+        if !isempty(records)
+            msg = string(records[1].message)
+            @test occursin("failed to precompile", msg)
+            @test haskey(records[1].kwargs, :exitcode)
+            @test haskey(records[1].kwargs, :precompilation)
+            # `Pkg.precompile(; io)` writes its summary (and any "missing from the
+            # cache" warnings) to `io`; the exception text itself goes to the worker's
+            # stderr, which is already forwarded. The summary names what failed.
+            @test occursin(
+                "FailsToPrecompile",
+                string(records[1].kwargs[:precompilation]),
+            )
+        end
+        filter!(str -> !occursin("PersistentTasks", str), LOAD_PATH)
+    end
+end
+
 @testset "test_persistent_tasks(expr)" begin
     if Base.VERSION >= v"1.10-"
         @test !Aqua.has_persistent_tasks(


### PR DESCRIPTION
## Problem

`test_persistent_tasks` spawns a wrapper package that `using`s the target package and, from inside precompilation, writes a `done.log` sentinel. If the subprocess exits without writing it, the check reports:

```
┌ Error: Unexpected error: /tmp/jl_XXXX/done.log was not created, but precompilation exited
Persistent tasks: Test Failed
```

and the test fails as though the package holds a persistent `Task`.

But the sentinel is also missing whenever the wrapper simply **failed to precompile**, which is a different problem with a different fix — and the reason is unrecoverable, because the child runs `Pkg.precompile(; io = devnull)`.

This matters most for the retryable `module is missing from the cache` race. That failure only *warns* and exits **0**, and the warning goes to `io`. With `io = devnull` the run looks like a clean exit with no sentinel, indistinguishable from a genuine persistent task.

I hit this downstream and it took a temporary patch to a CI job to recover the message. Once visible it was unambiguous:

```
34843.2 ms  ? jl_ji9KfebcbW
1 dependencies failed but may be precompilable after restarting julia
┌ jl_ji9KfebcbW
│  ┌ Warning: Module SciMLBaseDifferentiationInterfaceExt with build ID fafbfcfd-… is missing from the cache.
└  └ @ Base loading.jl:2643

done_log_written = false
exitcode = 0
termsignal = 0
```

Exit 0, no signal, no persistent task — a precompilation race. Before recovering that output I had ruled out a real persistent task, a native-library segfault, and memory exhaustion one at a time, because the check gives the same message for all of them.

## Change

Capture the child's precompilation output to a file inside the wrapper directory and, when the sentinel is missing, report it together with the subprocess exit code and termination signal, and note that a precompilation failure is the likelier cause:

```julia
@error "Unexpected error: … This usually means the wrapper package failed to precompile, \
        rather than that $pkgname holds a persistent task." \
       exitcode termsignal precompilation
```

Behavior is otherwise unchanged: the probe still returns `true`, output is still hidden on the happy path, and the "currently precompiling" branch is untouched. This only affects what is reported on failure.

Note the child's own stderr was already forwarded, so hard precompilation *errors* were partly visible; what was lost is everything Pkg writes to `io`, which is exactly where the missing-from-cache warning lands.

## Tests

New fixture `test/pkgs/PersistentTasks/FailsToPrecompile` that fails to precompile deterministically, plus a testset asserting the error names precompilation as the cause and carries `exitcode` and the captured output.

Full suite passes locally on Julia 1.12.6 — all 13 test files green, `test_persistent_tasks.jl` 12/12 (was 6).
