### PR TITLE
Increased concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   also raised to 30 seconds (still configurable) to reduce false positives when a
   package without persistent tasks is merely slow to shut down. ([#315])
 - Make `test_piracy` check modules recursively for type piracy. This may result in failures for downstream users. ([#377])
+- `test_all` runs its subprocess-based checks concurrently. On Julia 1.13 and
+  later, `find_persistent_tasks_deps` also checks dependencies concurrently.
+  ([#315])
 
 ## Version [v0.8.16] - 2026-06-05
 

--- a/docs/src/persistent_tasks.md
+++ b/docs/src/persistent_tasks.md
@@ -97,6 +97,10 @@ If precompilation instead fails outright (for example because a dependency
 cannot be precompiled), that is reported as a precompilation error rather than a
 persistent task, so the failure message points at the real cause.
 
+On Julia 1.13 and later, `find_persistent_tasks_deps` checks dependencies
+concurrently. Older Julia versions check them one at a time because concurrent
+environment instantiation is not safe there.
+
 ## How to fix failing packages
 
 Often, the easiest fix is to modify the `__init__` function to check whether the

--- a/src/Aqua.jl
+++ b/src/Aqua.jl
@@ -60,48 +60,86 @@ function test_all(
     persistent_tasks = true,
     undocumented_names = false,
 )
-    if ambiguities !== false
+    # Launch subprocess-based checks together, then record their Test results on
+    # this task. Persistent-task setup runs first because it changes Pkg state
+    # that the other checks read when launching their subprocesses.
+    persistent_tasks_launch = enabled(persistent_tasks) ?
+        Threads.@spawn(_launch_persistent_tasks(
+            PkgId(testtarget);
+            askwargs(persistent_tasks)...,
+        )) : nothing
+    ambiguities_task = nothing
+    stale_deps_task = nothing
+    persistent_tasks_task = nothing
+    tasks = Task[]
+    try
+        persistent_tasks_launch === nothing ||
+            timedwait(() -> istaskdone(persistent_tasks_launch), Inf)
+        ambiguities_task = enabled(ambiguities) ?
+            Threads.@spawn(_result_ambiguities(
+                aspkgids([testtarget]);
+                askwargs(ambiguities)...,
+            )) : nothing
+        stale_deps_task = enabled(stale_deps) ?
+            Threads.@spawn(find_stale_deps(
+                aspkgid(testtarget);
+                askwargs(stale_deps)...,
+            )) : nothing
+        persistent_tasks_task = persistent_tasks_launch === nothing ? nothing :
+            Threads.@spawn(_await_persistent_tasks(persistent_tasks_launch))
+        append!(tasks, filter(!isnothing, [
+            ambiguities_task, stale_deps_task, persistent_tasks_task
+        ]))
+        timedwait(() -> all(istaskdone, tasks), Inf)
+    finally
+        persistent_tasks_launch === nothing ||
+            _stop_persistent_tasks(persistent_tasks_launch)
+        timedwait(() -> all(istaskdone, tasks), Inf)
+    end
+
+    if enabled(ambiguities)
         @testset "Method ambiguity" begin
-            test_ambiguities([testtarget]; askwargs(ambiguities)...)
+            _report_ambiguities(fetch(ambiguities_task))
         end
     end
-    if unbound_args !== false
+    if enabled(unbound_args)
         @testset "Unbound type parameters" begin
             test_unbound_args(testtarget; askwargs(unbound_args)...)
         end
     end
-    if undefined_exports !== false
+    if enabled(undefined_exports)
         @testset "Undefined exports" begin
             test_undefined_exports(testtarget; askwargs(undefined_exports)...)
         end
     end
-    if project_extras !== false
+    if enabled(project_extras)
         @testset "Compare Project.toml and test/Project.toml" begin
             isempty(askwargs(project_extras)) || error("Keyword arguments not supported")
             test_project_extras(testtarget)
         end
     end
-    if stale_deps !== false
+    if enabled(stale_deps)
         @testset "Stale dependencies" begin
-            test_stale_deps(testtarget; askwargs(stale_deps)...)
+            stale = fetch(stale_deps_task)
+            @test isempty(stale)
         end
     end
-    if deps_compat !== false
+    if enabled(deps_compat)
         @testset "Compat bounds" begin
             test_deps_compat(testtarget; askwargs(deps_compat)...)
         end
     end
-    if piracies !== false
+    if enabled(piracies)
         @testset "Piracy" begin
             test_piracies(testtarget; askwargs(piracies)...)
         end
     end
-    if persistent_tasks !== false
+    if enabled(persistent_tasks)
         @testset "Persistent tasks" begin
-            test_persistent_tasks(testtarget; askwargs(persistent_tasks)...)
+            _report_persistent_tasks(fetch(persistent_tasks_task))
         end
     end
-    if undocumented_names !== false
+    if enabled(undocumented_names)
         @testset "Undocumented names" begin
             isempty(askwargs(undocumented_names)) ||
                 error("Keyword arguments not supported")

--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -67,17 +67,28 @@ function reprexclude(exspecs::Vector{ExcludeSpec})
     return string("Aqua.ExcludeSpec[", join(itemreprs, ", "), "]")
 end
 
-function _test_ambiguities(packages::Vector{PkgId}; broken::Bool = false, kwargs...)
+function _test_ambiguities(packages::Vector{PkgId}; kwargs...)
+    _report_ambiguities(_result_ambiguities(packages; kwargs...))
+end
+
+# Run the ambiguity-detection subprocess and return the data needed to report
+# the result. Separated from `_report_ambiguities` so that `test_all` can run
+# this subprocess concurrently with other checks and record the result
+# afterwards on the main task (where `Test` keeps its task-local state).
+function _result_ambiguities(packages::Vector{PkgId}; broken::Bool = false, kwargs...)
     num_ambiguities, strout, strerr =
         _find_ambiguities(packages; skipdetails = broken, kwargs...)
+    return (; num_ambiguities, strout, strerr, broken)
+end
 
-    print(stderr, strerr)
-    print(stdout, strout)
+function _report_ambiguities(result)
+    print(stderr, result.strerr)
+    print(stdout, result.strout)
 
-    if broken
-        @test_broken iszero(num_ambiguities)
+    if result.broken
+        @test_broken iszero(result.num_ambiguities)
     else
-        @test iszero(num_ambiguities)
+        @test iszero(result.num_ambiguities)
     end
 end
 

--- a/src/persistent_tasks.jl
+++ b/src/persistent_tasks.jl
@@ -47,9 +47,53 @@ function test_persistent_tasks(package::Module; kwargs...)
 end
 
 function has_persistent_tasks(package::PkgId; expr::Expr = quote end, tmax = 30)
+    launched = launch_persistent_tasks_check(package; expr)
+    return await_persistent_tasks_check(launched, tmax)
+end
+
+function launch_persistent_tasks_check(package::PkgId; expr::Expr = quote end)
+    @static VERSION >= v"1.10.0-" || return false
     root_project_path, found = root_project_toml(package)
     found || error("Unable to locate Project.toml")
-    return !precompile_wrapper(root_project_path, tmax, expr)
+    handle = launch_precompile_wrapper(root_project_path, expr)
+    handle === nothing && return true
+    return handle
+end
+
+await_persistent_tasks_check(verdict::Bool, tmax) = verdict
+await_persistent_tasks_check(handle, tmax) = !await_precompile_wrapper(handle, tmax)
+
+function _launch_persistent_tasks(
+    package::PkgId;
+    broken::Bool = false,
+    expr::Expr = quote end,
+    tmax = 30,
+)
+    launched = launch_persistent_tasks_check(package; expr)
+    return (; launched, broken, tmax)
+end
+
+function _await_persistent_tasks(launch_task)
+    pending = fetch(launch_task)
+    has = await_persistent_tasks_check(pending.launched, pending.tmax)
+    return (; has, broken = pending.broken)
+end
+
+function _report_persistent_tasks(result)
+    if result.broken
+        @test_broken !result.has
+    else
+        @test !result.has
+    end
+end
+
+function _stop_persistent_tasks(launch_task)
+    pending = try
+        fetch(launch_task)
+    catch
+        return
+    end
+    stop_precompile_wrapper(pending.launched)
 end
 
 """
@@ -66,12 +110,18 @@ function find_persistent_tasks_deps(package::PkgId; kwargs...)
     root_project_path, found = root_project_toml(package)
     found || error("Unable to locate Project.toml")
     prj = TOML.parsefile(root_project_path)
-    deps = get(prj, "deps", Dict{String,Any}())
-    filter!(deps) do (name, uuid)
-        id = PkgId(UUID(uuid), name)
-        return has_persistent_tasks(id; kwargs...)
+    deps = collect(get(prj, "deps", Dict{String,Any}()))
+    # Julia 1.12 and earlier cannot instantiate environments concurrently.
+    ntasks = if VERSION >= v"1.13-"
+        max(1, min(length(deps), Sys.CPU_THREADS))
+    else
+        1
     end
-    return String[name for (name, _) in deps]
+    results = asyncmap(deps; ntasks = ntasks) do (name, uuid)
+        id = PkgId(UUID(uuid), name)
+        return name => has_persistent_tasks(id; kwargs...)
+    end
+    return String[name for (name, hastasks) in results if hastasks]
 end
 
 function find_persistent_tasks_deps(package::Module; kwargs...)
@@ -82,24 +132,39 @@ function precompile_wrapper(project, tmax, expr)
     @static if VERSION < v"1.10.0-"
         return true
     end
-    prev_project = Base.active_project()::String
-    isdefined(Pkg, :respect_sysimage_versions) && Pkg.respect_sysimage_versions(false)
-    try
-        pkgdir = dirname(project)
-        pkgname = get(TOML.parsefile(project), "name", "")::String
-        if isempty(pkgname)
-            @error "Unable to locate package name in $project"
-            return false
-        end
-        wrapperdir = tempname()
-        wrappername, _ = only(Pkg.generate(wrapperdir; io = devnull))
-        Pkg.activate(wrapperdir; io = devnull)
-        Pkg.develop(PackageSpec(path = pkgdir); io = devnull)
-        statusfile = joinpath(wrapperdir, "done.log")
-        open(joinpath(wrapperdir, "src", wrappername * ".jl"), "w") do io
-            println(
-                io,
-                """
+    handle = launch_precompile_wrapper(project, expr)
+    handle === nothing && return false
+    return await_precompile_wrapper(handle, tmax)
+end
+
+# Pkg activation and sysimage-version handling are process-global.
+const PRECOMPILE_SETUP_LOCK = ReentrantLock()
+
+function launch_precompile_wrapper(project, expr)
+    pkgdir = dirname(project)
+    pkgname = get(TOML.parsefile(project), "name", "")::String
+    if isempty(pkgname)
+        @error "Unable to locate package name in $project"
+        return nothing
+    end
+    wrapperdir = tempname()
+    statusfile = joinpath(wrapperdir, "done.log")
+    errlog = joinpath(wrapperdir, "precompile-stderr.log")
+    currently_precompiling = @ccall(jl_generating_output()::Cint) == 1
+    lock(PRECOMPILE_SETUP_LOCK) do
+        prev_project = Base.active_project()::String
+        respect_sysimage_versions =
+            isdefined(Pkg, :respect_sysimage_versions) ?
+            Pkg.RESPECT_SYSIMAGE_VERSIONS[] : nothing
+        respect_sysimage_versions === nothing || Pkg.respect_sysimage_versions(false)
+        try
+            wrappername, _ = only(Pkg.generate(wrapperdir; io = devnull))
+            Pkg.activate(wrapperdir; io = devnull)
+            Pkg.develop(PackageSpec(path = pkgdir); io = devnull)
+            open(joinpath(wrapperdir, "src", wrappername * ".jl"), "w") do io
+                println(
+                    io,
+                    """
 module $wrappername
 using $pkgname
 $expr
@@ -110,61 +175,79 @@ open("$(escape_string(statusfile))", "w") do io
 end
 end
 """,
-            )
+                )
+            end
+        finally
+            respect_sysimage_versions === nothing ||
+                Pkg.respect_sysimage_versions(respect_sysimage_versions)
+            Pkg.activate(prev_project; io = devnull)
         end
-        # Precompile the wrapper package
-        currently_precompiling = @ccall(jl_generating_output()::Cint) == 1
-        cmd = if currently_precompiling
-            # During precompilation we run a dummy command that just touches the
-            # status file to keep things simple.
-            code = """touch("$(escape_string(statusfile))")"""
-            `$(Base.julia_cmd()) -e $code`
-        else
-            `$(Base.julia_cmd()) --project=$wrapperdir -e 'push!(LOAD_PATH, "@stdlib"); using Pkg; Pkg.precompile()'`
-        end
-
-        # Capture the subprocess's stderr so a genuine precompilation error can be
-        # reported on its own terms instead of masquerading as a persistent task.
-        errlog = joinpath(wrapperdir, "precompile-stderr.log")
-        cmd = pipeline(cmd; stdout = devnull, stderr = errlog)
-        proc = run(cmd; wait = false)::Base.Process
-
-        # Phase 1 (unbounded): wait for the package to finish loading. The wrapper
-        # writes `statusfile` once `using $pkgname` (and any `expr`) has run. Slow
-        # precompilation of the dependencies only prolongs this phase.
-        timedwait(() -> isfile(statusfile) || !process_running(proc), Inf; pollint = 0.5)
-        if !isfile(statusfile)
-            # The process exited before the package finished loading: a
-            # precompilation failure, not a persistent task.
-            wait(proc)
-            error(
-                "Loading `$pkgname` for the persistent-task check failed before " *
-                "precompilation completed (process exited with code " *
-                "$(proc.exitcode), signal $(proc.termsignal)). This indicates a " *
-                "precompilation error, not a persistent task." *
-                (isfile(errlog) ? "\nCaptured output:\n\n" * read(errlog, String) : ""),
-            )
-        end
-
-        # Phase 2 (bounded by `tmax`): the package loaded cleanly. A persistent task
-        # keeps the process from exiting, so it hangs indefinitely. A healthy package
-        # exits once its shutdown finishes, so allow up to `tmax` seconds for it.
-        timedwait(() -> !process_running(proc), tmax; pollint = 0.1)
-        success = !process_running(proc)
-        if !success
-            @warn(
-                "Loading `$pkgname` prevented the precompilation process from " *
-                "exiting within $tmax seconds, which usually means a persistent " *
-                "task is still running. If `$pkgname` is free of persistent tasks, " *
-                "re-run with a larger `tmax` to give its shutdown more time."
-            )
-            # SIGKILL to prevent julia from printing the SIG 15 handler, which can
-            # misleadingly look like it's caused by an issue in the user's program.
-            kill(proc, Base.SIGKILL)
-        end
-        return success
-    finally
-        isdefined(Pkg, :respect_sysimage_versions) && Pkg.respect_sysimage_versions(true)
-        Pkg.activate(prev_project; io = devnull)
     end
+    # Precompile the wrapper package
+    cmd = if currently_precompiling
+        # During precompilation we run a dummy command that just touches the
+        # status file to keep things simple.
+        code = """touch("$(escape_string(statusfile))")"""
+        `$(Base.julia_cmd()) -e $code`
+    else
+        `$(Base.julia_cmd()) --project=$wrapperdir -e 'push!(LOAD_PATH, "@stdlib"); using Pkg; Pkg.precompile()'`
+    end
+
+    # Capture the subprocess's stderr so a genuine precompilation error can be
+    # reported on its own terms instead of masquerading as a persistent task.
+    cmd = pipeline(cmd; stdout = devnull, stderr = errlog)
+    proc = run(cmd; wait = false)::Base.Process
+    return (; proc, statusfile, errlog, pkgname)
+end
+
+function await_precompile_wrapper(handle, tmax)
+    proc = handle.proc
+    statusfile = handle.statusfile
+    pkgname = handle.pkgname
+
+    # Loading time does not count against the persistent-task timeout.
+    timedwait(() -> isfile(statusfile) || !process_running(proc), Inf; pollint = 0.5)
+    if !isfile(statusfile)
+        precompile_error(handle)
+    end
+
+    # Once loaded, a process that does not exit within `tmax` has a persistent task.
+    timedwait(() -> !process_running(proc), tmax; pollint = 0.1)
+    if process_running(proc)
+        @warn(
+            "Loading `$pkgname` prevented the precompilation process from " *
+            "exiting within $tmax seconds, which usually means a persistent " *
+            "task is still running. If `$pkgname` is free of persistent tasks, " *
+            "re-run with a larger `tmax` to give its shutdown more time."
+        )
+        # SIGKILL to prevent julia from printing the SIG 15 handler, which can
+        # misleadingly look like it's caused by an issue in the user's program.
+        kill(proc, Base.SIGKILL)
+        wait(proc)
+        return false
+    end
+    wait(proc)
+    iszero(proc.exitcode) || precompile_error(handle)
+    return true
+end
+
+function precompile_error(handle)
+    proc = handle.proc
+    wait(proc)
+    error(
+        "Loading `$(handle.pkgname)` for the persistent-task check failed " *
+        "during precompilation (process exited with code $(proc.exitcode), " *
+        "signal $(proc.termsignal)). This indicates a precompilation error, " *
+        "not a persistent task." *
+        (
+            isfile(handle.errlog) ?
+            "\nCaptured output:\n\n" * read(handle.errlog, String) : ""
+        ),
+    )
+end
+
+stop_precompile_wrapper(::Bool) = nothing
+function stop_precompile_wrapper(handle)
+    process_running(handle.proc) && kill(handle.proc, Base.SIGKILL)
+    wait(handle.proc)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,6 +6,9 @@ function askwargs(flag::Bool)
     return NamedTuple()
 end
 
+# A NamedTuple enables a test and supplies its keyword arguments.
+enabled(flag) = flag !== false
+
 aspkgids(pkg::Union{Module,PkgId}) = aspkgids([pkg])
 aspkgids(packages) = mapfoldl(aspkgid, push!, packages, init = PkgId[])
 

--- a/test/test_persistent_tasks.jl
+++ b/test/test_persistent_tasks.jl
@@ -2,6 +2,7 @@ module TestPersistentTasks
 
 include("preamble.jl")
 using Base: PkgId, UUID
+import Pkg
 using Pkg: TOML
 
 function getid(name)
@@ -15,7 +16,18 @@ end
 
 
 @testset "PersistentTasks" begin
-    @test !Aqua.has_persistent_tasks(getid("TransientTask"))
+    if Base.VERSION >= v"1.10-"
+        respect_sysimage_versions = Pkg.RESPECT_SYSIMAGE_VERSIONS[]
+        Pkg.respect_sysimage_versions(false)
+        try
+            @test !Aqua.has_persistent_tasks(getid("TransientTask"))
+            @test !Pkg.RESPECT_SYSIMAGE_VERSIONS[]
+        finally
+            Pkg.respect_sysimage_versions(respect_sysimage_versions)
+        end
+    else
+        @test !Aqua.has_persistent_tasks(getid("TransientTask"))
+    end
 
     result = Aqua.find_persistent_tasks_deps(getid("TransientTask"))
     @test result == []
@@ -29,6 +41,23 @@ end
         @test result == ["PersistentTask"]
     end
     filter!(str -> !occursin("PersistentTasks", str), LOAD_PATH)
+end
+
+@testset "subprocess exit handling" begin
+    if Base.VERSION >= v"1.10-"
+        statusfile = tempname()
+        errlog = tempname()
+        write(errlog, "failure after loading")
+        proc = run(`$(Base.julia_cmd()) --startup-file=no -e 'exit(7)'`; wait = false)
+        touch(statusfile)
+        handle = (; proc, statusfile, errlog, pkgname = "FailedAfterLoading")
+        @test_throws "process exited with code 7" Aqua.await_precompile_wrapper(handle, 1)
+
+        proc = run(`$(Base.julia_cmd()) --startup-file=no -e 'sleep(60)'`; wait = false)
+        handle = (; proc, statusfile, errlog, pkgname = "Stopped")
+        Aqua.stop_precompile_wrapper(handle)
+        @test !process_running(proc)
+    end
 end
 
 @testset "precompilation failure is reported as an error" begin

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,6 +1,6 @@
 module TestUtils
 
-using Aqua: askwargs
+using Aqua: askwargs, enabled
 using Test
 
 @testset "askwargs" begin
@@ -8,6 +8,12 @@ using Test
     @test askwargs(true) === NamedTuple()
     @test askwargs(()) === NamedTuple()
     @test askwargs((a = 1,)) === (a = 1,)
+end
+
+@testset "enabled" begin
+    @test enabled(true)
+    @test enabled((broken = true,))
+    @test !enabled(false)
 end
 
 end  # module


### PR DESCRIPTION
This reduces test time by increasing concurrency.
This is mostly still at the vibe-coding state as I have not gone through all the changes. I want to avoid that this gets lost, so I create a draft PR, but it probably makes sense to first finish #389/#390 – first make it work (correctly), then make it fast.